### PR TITLE
Setting APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -432,6 +433,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Per the documentation:

```
When enabled, this causes the compiler and linker to
disallow use of APIs that are not available
to app extensions and to disallow linking to frameworks
that have not been built with this setting enabled.
```

Since we're not using any of these APIs, we can safely turn this setting on.

Related: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1891
This is in preparation for https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1887.

Note: I set this at the project level so that it affects both iOS and Mac.