### PR TITLE
Lazily evaluated result coalescing

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -73,8 +73,8 @@ public enum Result<T, Error>: Printable, DebugPrintable {
 	}
 	
 	/// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
-	public func recover(value: T) -> T {
-		return self.value ?? value
+	public func recover(@autoclosure value: () -> T) -> T {
+		return self.value ?? value()
 	}
 	
 	/// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -78,10 +78,10 @@ public enum Result<T, Error>: Printable, DebugPrintable {
 	}
 	
 	/// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
-	public func recoverWith(result: Result<T,Error>) -> Result<T,Error> {
+	public func recoverWith(@autoclosure result: () -> Result<T,Error>) -> Result<T,Error> {
 		return analysis(
 			ifSuccess: { _ in self },
-			ifFailure: { _ in result })
+			ifFailure: { _ in result() })
 	}
 
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -1,7 +1,5 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-import Box
-
 /// An enum representing either a failure with an explanatory error, or a success with a result value.
 public enum Result<T, Error>: Printable, DebugPrintable {
 	case Success(Box<T>)
@@ -199,6 +197,5 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 }
 
 
-// MARK: - Imports
-
+import Box
 import Foundation


### PR DESCRIPTION
`??` used `@autoclosure` but since `recover`/`recoverWith` did not, it made no difference: the right hand operand would always be evaluated eagerly.

The fix is to use `@autoclosure` for `recover` and `recoverWith`, which I believe is correct for their semantics as well.

h/t @esttorhe: https://twitter.com/esttorhe/status/598962925685080064