### PR TITLE
Make >>- operator precedence compatible with other frameworks.

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -191,7 +191,7 @@ infix operator >>- {
 	associativity left
 
 	// Higher precedence than function application, but lower than function composition.
-	precedence 150
+	precedence 100
 }
 
 infix operator &&& {


### PR DESCRIPTION
The Runes framework has [changed its >>- operator precedence](thoughtbot/Runes@d3a7d6352339a45ce307f4c579bf4e0048df334b) to be more like Haskells, see https://github.com/thoughtbot/Runes/pull/30. This means you can't use Runes, Result and >>- in the same Swift file because the compiler complains about ambiguous operator precedence definitions. I ran into this problem with a version of [Gordon Fontenots implementation of <*> and <^> for Result](https://github.com/kareman/FootlessParser/blob/master/source/General/Result%2BOperators.swift).

https://github.com/robrix/Either/pull/28 and https://github.com/robrix/Madness/pull/86 have also made the same change.