### PR TITLE
[RFC] Use Runes as an optional dependency for functional operators

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Carthage/Checkouts/Runes"]
+	path = Carthage/Checkouts/Runes
+	url = https://github.com/thoughtbot/Runes.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "thoughtbot/Runes" "gf-framework-dependency"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "thoughtbot/Runes" "269bee6e51b4b9de5c2658f1927a8fa6a1a731f8"

--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D45480981A957465009D7229 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45480961A957465009D7229 /* Result.swift */; };
 		D45480991A9574B8009D7229 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D454806E1A9572F5009D7229 /* ResultTests.swift */; };
 		D454809A1A9574BB009D7229 /* Result.h in Headers */ = {isa = PBXBuildFile; fileRef = D454805C1A9572F5009D7229 /* Result.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F80EABB61B28B4640013350E /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80EABB51B28B4640013350E /* Runes.swift */; };
+		F80EABB71B28B4640013350E /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80EABB51B28B4640013350E /* Runes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +46,7 @@
 		D454807D1A957361009D7229 /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D45480871A957362009D7229 /* Result-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Result-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D45480961A957465009D7229 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		F80EABB51B28B4640013350E /* Runes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Runes.swift; path = Carthage/Checkouts/Runes/Source/Runes.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +109,7 @@
 			children = (
 				D454805C1A9572F5009D7229 /* Result.h */,
 				D45480961A957465009D7229 /* Result.swift */,
+				F80EABB51B28B4640013350E /* Runes.swift */,
 				D454805A1A9572F5009D7229 /* Supporting Files */,
 			);
 			path = Result;
@@ -311,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D45480971A957465009D7229 /* Result.swift in Sources */,
+				F80EABB61B28B4640013350E /* Runes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D45480981A957465009D7229 /* Result.swift in Sources */,
+				F80EABB71B28B4640013350E /* Runes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -186,14 +186,6 @@ public func `try`(function: String = __FUNCTION__, file: String = __FILE__, line
 
 // MARK: - Operators
 
-infix operator >>- {
-	// Left-associativity so that chaining works like you’d expect, and for consistency with Haskell, Runes, swiftz, etc.
-	associativity left
-
-	// Higher precedence than function application, but lower than function composition.
-	precedence 100
-}
-
 infix operator &&& {
 	/// Same associativity as &&.
 	associativity left


### PR DESCRIPTION
Been thinking about this a lot lately, and wanted to open up a discussion about it.

Issues like #49 seem like a smell to me. Needing to maintain duplicate and parallel operator definitions in order to maintain compatibility with other libraries screams "shared dependency" to me. Ideally, I think [Runes](https://github.com/thoughtbot/runes) (or a similar lib) would define the operators, and then `Result` would define implementations for the types it exposes. That would allow the operators to have a single point of definition, and guarantee consistency for things like precedence.

Obviously, it's not that simple. Adding Runes as a dependency would mean needing to expose another framework that users would need to link against, even if they never use it. I think we're all in agreement that a lib like this should have as few dependencies as possible. `Box` makes sense, but adding in a dependency on `Runes` (especially after we've already pulled out the dependencies on `Either` and `Prelude`) doesn't.

Ideally, we'd be able to do some sort of optional dependency. It would be awesome to be able to say "Is Runes available? If so, here's this implementation of `flatMap` for result that you can use". (It would be _more_ awesome to be able to define some sort of generic type for this. Like a higher kind of type. idk) But unfortunately Apple hasn't provided a way to do that.

As a temporary solution, what if the duplicate operators were moved into a second framework that included Runes as a dependency, leaving the basic `Result` framework pure?

__PROS__
- Users that never use `>>-` or any of the other operators would never see them, and would never need to worry about them
- Users that _do_ use `>>-` and so forth wouldn't have to worry about conflicting operator definitions.
- Using a common dependency that implements these same operators for `Optional` and `Array` would theoretically increase exposure to these operators, driving education and adoption.

__CONS__
- This would require users that want `>>-` to import a module that is named something other than `Result`. `ResultRunes` or `ResultOperators` or whatever. That's fairly gross.
- When using Carthage to install `Result`, users would be left with 5(!) frameworks in their build directory. They would then have to know which ones to link to get what they want.

As a side note, this would be able to be implemented for CocoaPods by using subspecs. CP users would then only need to import `Result` no matter what, using a spec similar to this:

```ruby
Pod::Spec.new do |s|
  s.name         = 'Result'
  s.version      = '0.4.3'
  s.summary      = 'Swift type modelling the success/failure of arbitrary operations'

  s.homepage     = 'https://github.com/antitypical/Result'
  s.license      = 'MIT'
  s.author       = { 'Rob Rix' => 'rob.rix@github.com' }
  s.source       = { :git => 'https://github.com/antitypical/Result.git', :tag => s.version.to_s }
  s.source_files  = 'Result/Result.swift'
  s.requires_arc = true
  s.ios.deployment_target = '8.0'
  s.osx.deployment_target = '10.9'

  subspec 'Runes' do |subspec|
    subspec.source_files = 'Result/Runes.swift'
    subspec.dependency 'Runes', '>= 1.2.2'
  end
end
```

CP users would then be able to declare `pod 'Result/Runes'` and they would get both.

I don't think this PR should be used as the final implementation by the way, but meant it more as an example of how this _could_ work in the service of conversation.