### PR TITLE
Add `transform` for functions using `throws`

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -84,8 +84,8 @@ public enum Result<T, Error>: CustomStringConvertible, CustomDebugStringConverti
 			ifFailure: { _ in result() })
 	}
 
-	/// Returns a transformed function that used `throws` to one that uses `Result`
-	public static func transform<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
+	/// Transform a function from one that uses `throw` to one that returns a `Result`
+	public static func materialize<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
 		return { x in
 			do {
 				return .success(try f(x))

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -84,6 +84,17 @@ public enum Result<T, Error>: CustomStringConvertible, CustomDebugStringConverti
 			ifFailure: { _ in result() })
 	}
 
+	/// Returns a transformed function that used `throws` to one that uses `Result`
+	public static func transform<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
+		return { x in
+			do {
+				return .success(try f(x))
+			} catch {
+				return .failure(error)
+			}
+		}
+	}
+
 
 	// MARK: Errors
 


### PR DESCRIPTION
This introduces a new higher order function that takes a function that
uses the new `throws` functionality introduced in Swift 2.0 and wraps
it to turn it into a function that returns a `Result` type

hat tip @radex
https://twitter.com/radexp/status/608208346777325568