### PR TITLE
Conform error cases to ErrorType

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// An enum representing either a failure with an explanatory error, or a success with a result value.
-public enum Result<T, Error>: CustomStringConvertible, CustomDebugStringConvertible {
+public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStringConvertible {
 	case Success(T)
 	case Failure(Error)
 


### PR DESCRIPTION
This is provided by the stdlib, it makes sense for us to conform to it.

As per discussion in #56