### PR TITLE
Add `extract` function for deconstruction

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -45,6 +45,15 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
 	}
 
+	public func extract() throws -> T {
+		switch self {
+		case let .Success(value):
+			return value
+		case let .Failure(error):
+			throw error
+		}
+	}
+
 	/// Case analysis for Result.
 	///
 	/// Returns the value produced by applying `ifFailure` to `Failure` Results, or `ifSuccess` to `Success` Results.

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -45,7 +45,8 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
 	}
 
-	public func extract() throws -> T {
+	/// Returns the value from `Success` Results or `throw`s the error
+	public func dematerialize() throws -> T {
 		switch self {
 		case let .Success(value):
 			return value


### PR DESCRIPTION
This function extracts the value or throws the error.

As per discussion in #56 /cc @radix
Depends on #57 