### PR TITLE
Add function version of `materialize`

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -181,12 +181,12 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 
 // MARK: - Derive result from failable closure
 
-public func materialize<T>(f: () throws -> T) -> Result<T, ErrorType> {
-	do {
-		return .success(try f())
-	} catch {
-		return .failure(error)
-	}
+public func materialize<T, E: ErrorType>(f: () throws -> T) -> Result<T, E> {
+    do {
+        return .success(try f())
+    } catch {
+        return .failure(error as! E)
+    }
 }
 
 // MARK: - Cocoa API conveniences

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -181,12 +181,12 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 
 // MARK: - Derive result from failable closure
 
-public func materialize<T, E: ErrorType>(f: () throws -> T) -> Result<T, E> {
-    do {
-        return .success(try f())
-    } catch {
-        return .failure(error as! E)
-    }
+public func materialize<T>(f: () throws -> T) -> Result<T, ErrorType> {
+	do {
+		return .success(try f())
+	} catch {
+		return .failure(error)
+	}
 }
 
 // MARK: - Cocoa API conveniences

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -179,6 +179,15 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 	return left.recoverWith(right())
 }
 
+// MARK: - Derive result from failable closure
+
+public func materialize<T>(f: () throws -> T) -> Result<T, ErrorType> {
+	do {
+		return .success(try f())
+	} catch {
+		return .failure(error)
+	}
+}
 
 // MARK: - Cocoa API conveniences
 


### PR DESCRIPTION
CAUTION: This patch is also not working for now in the same way as #56 .
https://twitter.com/gfontenot/status/608774708159324161

#56 is great, but function version of `materialize` is easier to derive `Result` from failable closure.

```swift
let data = NSData()
let result = materialize {
	try NSJSONSerialization.JSONObjectWithData(data, options: [])
}
```