### PR TITLE
Comment out `materialize` due to compiler segfault

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -95,15 +95,15 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 	}
 
 	/// Transform a function from one that uses `throw` to one that returns a `Result`
-	public static func materialize<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
-		return { x in
-			do {
-				return .success(try f(x))
-			} catch {
-				return .failure(error)
-			}
-		}
-	}
+//	public static func materialize<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
+//		return { x in
+//			do {
+//				return .success(try f(x))
+//			} catch {
+//				return .failure(error)
+//			}
+//		}
+//	}
 
 
 	// MARK: Errors


### PR DESCRIPTION
Mixing multi-payload enums, generics, and type constraints results in a
bad time. There's no workaround that I could find, so it's probably best
to just comment this out for now till the compiler bug is fixed.

Radar: http://www.openradar.me/21341337