### PR TITLE
Remove commented out `materialize` and replace it with a Result constructor

### DIFF
--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45AE89E61B3A6564007B99D7 /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93621451B35596200948F2A /* ResultType.swift */; };
 		D035799B1B2B788F005D26AE /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45480961A957465009D7229 /* Result.swift */; };
 		D035799E1B2B788F005D26AE /* Result.h in Headers */ = {isa = PBXBuildFile; fileRef = D454805C1A9572F5009D7229 /* Result.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D03579A91B2B78A1005D26AE /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D454806E1A9572F5009D7229 /* ResultTests.swift */; };
@@ -404,6 +405,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45AE89E61B3A6564007B99D7 /* ResultType.swift in Sources */,
 				D035799B1B2B788F005D26AE /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -760,10 +760,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -781,10 +778,7 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ResultTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -22,6 +22,15 @@ public enum Result<T, Error: ErrorType>: ResultType, CustomStringConvertible, Cu
 		self = value.map(Result.Success) ?? .Failure(failWith())
 	}
 
+	/// Constructs a result from a function that uses `throw`, failing with `Error` if throws
+	public init(@autoclosure _ f: () throws -> T) {
+		do {
+			self = .Success(try f())
+		} catch {
+			self = .Failure(error as! Error)
+		}
+	}
+	
 
 	// MARK: Deconstruction
 

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -22,7 +22,7 @@ final class ResultTests: XCTestCase {
 
 	func testErrorsIncludeTheSourceFile() {
 		let file = __FILE__
-		XCTAssertEqual(Result<(), NSError>.error().file ?? "", file)
+		XCTAssert(Result<(), NSError>.error().file == file)
 	}
 
 	func testErrorsIncludeTheSourceLine() {
@@ -32,9 +32,20 @@ final class ResultTests: XCTestCase {
 
 	func testErrorsIncludeTheCallingFunction() {
 		let function = __FUNCTION__
-		XCTAssertEqual(Result<(), NSError>.error().function ?? "", function)
+		XCTAssert(Result<(), NSError>.error().function == function)
 	}
 
+	// MARK: Try - Catch
+	
+	func testTryCatchProducesSuccesses() {
+		let result: Result<String, NSError> = Result(try tryIsSuccess("success"))
+		XCTAssert(result == success)
+	}
+	
+	func testTryCatchProducesFailures() {
+		let result: Result<String, NSError> = Result(try tryIsSuccess(nil))
+		XCTAssert(result.error == error)
+	}
 
 	// MARK: Cocoa API idioms
 
@@ -102,6 +113,14 @@ func attempt<T>(value: T, succeed: Bool, error: NSErrorPointer) -> T? {
 		error.memory = Result<(), NSError>.error()
 		return nil
 	}
+}
+
+func tryIsSuccess(text: String?) throws -> String {
+	guard let text = text else {
+		throw error
+	}
+	
+	return text
 }
 
 extension NSError {


### PR DESCRIPTION
- had to Comment out `testErrorsIncludeTheSourceFile` and `testErrorsIncludeTheCallingFunction ` due to compiler segfault
- minor iOS tests target cleanup suppressing the following error: `ld: warning: directory not found for option '-F/Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk/Developer/Library/Frameworks'`