### PR TITLE
Add ResultType protocol to facilitate protocol extension constraints

### DIFF
--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D45480981A957465009D7229 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45480961A957465009D7229 /* Result.swift */; };
 		D45480991A9574B8009D7229 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D454806E1A9572F5009D7229 /* ResultTests.swift */; };
 		D454809A1A9574BB009D7229 /* Result.h in Headers */ = {isa = PBXBuildFile; fileRef = D454805C1A9572F5009D7229 /* Result.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E93621461B35596200948F2A /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93621451B35596200948F2A /* ResultType.swift */; };
+		E93621471B35596200948F2A /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93621451B35596200948F2A /* ResultType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +46,7 @@
 		D454807D1A957361009D7229 /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D45480871A957362009D7229 /* Result-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Result-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D45480961A957465009D7229 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		E93621451B35596200948F2A /* ResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +109,7 @@
 			children = (
 				D454805C1A9572F5009D7229 /* Result.h */,
 				D45480961A957465009D7229 /* Result.swift */,
+				E93621451B35596200948F2A /* ResultType.swift */,
 				D454805A1A9572F5009D7229 /* Supporting Files */,
 			);
 			path = Result;
@@ -310,6 +314,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E93621461B35596200948F2A /* ResultType.swift in Sources */,
 				D45480971A957465009D7229 /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -326,6 +331,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E93621471B35596200948F2A /* ResultType.swift in Sources */,
 				D45480981A957465009D7229 /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -131,6 +131,21 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 	}
 }
 
+public protocol ResultType {
+	typealias Value
+	typealias Error: ErrorType
+	
+	var value: Value? { get }
+	var error: Error? { get }
+	
+	init(value: Value)
+	init(error: Error)
+	
+	func analysis<U>(@noescape ifSuccess ifSuccess: Value -> U, @noescape ifFailure: Error -> U) -> U
+}
+
+extension Result: ResultType { }
+
 
 /// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
 public func == <T: Equatable, Error: Equatable> (left: Result<T, Error>, right: Result<T, Error>) -> Bool {

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// An enum representing either a failure with an explanatory error, or a success with a result value.
-public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStringConvertible {
+public enum Result<T, Error: ErrorType>: ResultType, CustomStringConvertible, CustomDebugStringConvertible {
 	case Success(T)
 	case Failure(Error)
 
@@ -34,16 +34,6 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 
 
 	// MARK: Deconstruction
-
-	/// Returns the value from `Success` Results, `nil` otherwise.
-	public var value: T? {
-		return analysis(ifSuccess: { $0 }, ifFailure: { _ in nil })
-	}
-
-	/// Returns the error from `Failure` Results, `nil` otherwise.
-	public var error: Error? {
-		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
-	}
 
 	/// Case analysis for Result.
 	///
@@ -130,22 +120,6 @@ public enum Result<T, Error: ErrorType>: CustomStringConvertible, CustomDebugStr
 		return description
 	}
 }
-
-public protocol ResultType {
-	typealias Value
-	typealias Error: ErrorType
-	
-	var value: Value? { get }
-	var error: Error? { get }
-	
-	init(value: Value)
-	init(error: Error)
-	
-	func analysis<U>(@noescape ifSuccess ifSuccess: Value -> U, @noescape ifFailure: Error -> U) -> U
-}
-
-extension Result: ResultType { }
-
 
 /// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
 public func == <T: Equatable, Error: Equatable> (left: Result<T, Error>, right: Result<T, Error>) -> Bool {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -1,0 +1,24 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public protocol ResultType {
+	typealias Value
+	typealias Error: ErrorType
+	
+	init(value: Value)
+	init(error: Error)
+	
+	func analysis<U>(@noescape ifSuccess ifSuccess: Value -> U, @noescape ifFailure: Error -> U) -> U
+}
+
+public extension ResultType {
+	
+	/// Returns the value from `Success` Results, `nil` otherwise.
+	var value: Value? {
+		return analysis(ifSuccess: { $0 }, ifFailure: { _ in nil })
+	}
+	
+	/// Returns the error from `Failure` Results, `nil` otherwise.
+	var error: Error? {
+		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
+	}
+}

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -5,7 +5,7 @@ public protocol ResultType {
 	typealias Value
 	typealias Error: ErrorType
 	
-	/// Constructs a succesful result wrapping a `value`.
+	/// Constructs a successful result wrapping a `value`.
 	init(value: Value)
 
 	/// Constructs a failed result wrapping an `error`.

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -1,23 +1,30 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+/// A type that can represent either failure with an error or success with a result value.
 public protocol ResultType {
 	typealias Value
 	typealias Error: ErrorType
 	
+	/// Constructs a succesful result wrapping a `value`.
 	init(value: Value)
+
+	/// Constructs a failed result wrapping an `error`.
 	init(error: Error)
 	
+	/// Case analysis for ResultType.
+	///
+	/// Returns the value produced by appliying `ifFailure` to the error if self represents a failure, or `ifSuccess` to the result value if self represents a success.
 	func analysis<U>(@noescape ifSuccess ifSuccess: Value -> U, @noescape ifFailure: Error -> U) -> U
 }
 
 public extension ResultType {
 	
-	/// Returns the value from `Success` Results, `nil` otherwise.
+	/// Returns the value if self represents a success, `nil` otherwise.
 	var value: Value? {
 		return analysis(ifSuccess: { $0 }, ifFailure: { _ in nil })
 	}
 	
-	/// Returns the error from `Failure` Results, `nil` otherwise.
+	/// Returns the error if self represents a failure, `nil` otherwise.
 	var error: Error? {
 		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
 	}


### PR DESCRIPTION
Protocols are really powerful in Swift and with Swift 2.0 even more so. By adding the `ResultType` protocol, we can use the type in protocol extensions and in generic constraints.

The primary motivation for this PR is a refactoring of BrightFutures (which has Result as a dependency) that I am working on. With the help of the `ResultType` protocol, I can define a simple `Deferred<T>` type and add methods (such as `onSuccess` and `onFailure`) to it when `T: ResultType`. 
- Relevant code in BrightFutures: https://gist.github.com/Thomvis/0684c36159d173396297ub.com/Thomvis/BrightFutures/blob/swiftier-2.0/BrightFutures/Future.swift#L112
- Concise example:  https://gist.github.com/Thomvis/0684c36159d173396297

The contents of the protocol is debatable, but the current contents are the parts that I found helpful.

:star2: Let me know what you think!