### PR TITLE
Update materialize functions

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -158,14 +158,13 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 
 // MARK: - Derive result from failable closure
 
-// Disable until http://www.openradar.me/21341337 is fixed.
-//public func materialize<T>(f: () throws -> T) -> Result<T, ErrorType> {
-//	do {
-//		return .Success(try f())
-//	} catch {
-//		return .Failure(error)
-//	}
-//}
+public func materialize<T>(f: () throws -> T) -> Result<T, NSError> {
+	do {
+		return .Success(try f())
+	} catch {
+		return .Failure(error as NSError)
+	}
+}
 
 // MARK: - Cocoa API conveniences
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -83,18 +83,6 @@ public enum Result<T, Error: ErrorType>: ResultType, CustomStringConvertible, Cu
 			ifFailure: { _ in result() })
 	}
 
-	/// Transform a function from one that uses `throw` to one that returns a `Result`
-//	public static func materialize<T, U>(f: T throws -> U) -> T -> Result<U, ErrorType> {
-//		return { x in
-//			do {
-//				return .Success(try f(x))
-//			} catch {
-//				return .Failure(error)
-//			}
-//		}
-//	}
-
-
 	// MARK: Errors
 
 	/// The domain for errors constructed by Result.


### PR DESCRIPTION
- Enable free materialize function and use NSError:

That bug isn't fixed yet, but this also won't ever compile. Somewhat
Reasonably, you are unable to use a protocol as a concrete type for a
generic type that has a type constraint with that protocol.

To get around this, we should use `NSError` for the error type, since we
can always safely cast from `ErrorType` to `NSError`.

Not sure if we should make this change to the initializer as well. Seems like
it might be safer than using a force cast. 

- Remove static `materialize` function:

Now that we have the initializer that takes a function, this seems less
interesting. Returning a function is much less useful than just passing a
function and getting a Result.