### PR TITLE
Move map, flatMap, and &&& to ResultType

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -189,24 +189,11 @@ infix operator >>- {
 	precedence 100
 }
 
-infix operator &&& {
-	/// Same associativity as &&.
-	associativity left
-
-	/// Same precedence as &&.
-	precedence 120
-}
-
 /// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
 ///
 /// This is a synonym for `flatMap`.
 public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T -> Result<U, Error>) -> Result<U, Error> {
 	return result.flatMap(transform)
-}
-
-/// Returns a Result with a tuple of `left` and `right` values if both are `Success`es, or re-wrapping the error of the earlier `Failure`.
-public func &&& <T, U, Error> (left: Result<T, Error>, @autoclosure right: () -> Result<U, Error>) -> Result<(T, U), Error> {
-	return left.flatMap { left in right().map { right in (left, right) } }
 }
 
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -58,18 +58,6 @@ public enum Result<T, Error: ErrorType>: ResultType, CustomStringConvertible, Cu
 
 
 	// MARK: Higher-order functions
-
-	/// Returns a new Result by mapping `Success`es’ values using `transform`, or re-wrapping `Failure`s’ errors.
-	public func map<U>(@noescape transform: T -> U) -> Result<U, Error> {
-		return flatMap { .Success(transform($0)) }
-	}
-
-	/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
-	public func flatMap<U>(@noescape transform: T -> Result<U, Error>) -> Result<U, Error> {
-		return analysis(
-			ifSuccess: transform,
-			ifFailure: Result<U, Error>.Failure)
-	}
 	
 	/// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
 	public func recover(@autoclosure value: () -> T) -> T {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -35,7 +35,7 @@ public extension ResultType {
 	}
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
-	func flatMap<U>(@noescape transform: Value -> Result<U, Error>) -> Result<U, Error> {
+	public func flatMap<U>(@noescape transform: Value -> Result<U, Error>) -> Result<U, Error> {
 		return analysis(
 			ifSuccess: transform,
 			ifFailure: Result<U, Error>.Failure)

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -45,11 +45,11 @@ public extension ResultType {
 // MARK: - Operators
 
 infix operator &&& {
-/// Same associativity as &&.
-associativity left
+	/// Same associativity as &&.
+	associativity left
 
-/// Same precedence as &&.
-precedence 120
+	/// Same precedence as &&.
+	precedence 120
 }
 
 /// Returns a Result with a tuple of `left` and `right` values if both are `Success`es, or re-wrapping the error of the earlier `Failure`.

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -28,4 +28,16 @@ public extension ResultType {
 	var error: Error? {
 		return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
 	}
+
+	/// Returns a new Result by mapping `Success`es’ values using `transform`, or re-wrapping `Failure`s’ errors.
+	public func map<U>(@noescape transform: Value -> U) -> Result<U, Error> {
+		return flatMap { .Success(transform($0)) }
+	}
+
+	/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
+	func flatMap<U>(@noescape transform: Value -> Result<U, Error>) -> Result<U, Error> {
+		return analysis(
+			ifSuccess: transform,
+			ifFailure: Result<U, Error>.Failure)
+	}
 }

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -41,3 +41,18 @@ public extension ResultType {
 			ifFailure: Result<U, Error>.Failure)
 	}
 }
+
+// MARK: - Operators
+
+infix operator &&& {
+/// Same associativity as &&.
+associativity left
+
+/// Same precedence as &&.
+precedence 120
+}
+
+/// Returns a Result with a tuple of `left` and `right` values if both are `Success`es, or re-wrapping the error of the earlier `Failure`.
+public func &&& <L: ResultType, R: ResultType where L.Error == R.Error> (left: L, @autoclosure right: () -> R) -> Result<(L.Value, R.Value), L.Error> {
+	return left.flatMap { left in right().map { right in (left, right) } }
+}


### PR DESCRIPTION
As it stand, these can all be implemented in terms of `ResultType`. And doing so opens up the possibilities for more things, like this:

```swift
extension SequenceType where Generator.Element: ResultType {
    /// Flattens a sequence of Results
    ///
    /// Returns a single Result by combining the values of all `Success`es in this sequence, or re-wrapping the first encountered `Failure`
    func flatten() -> Result<[Generator.Element.Value], Generator.Element.Error> {
        return reduce(.Success([])) { result, element in
            return (result &&& element).map { $0 + [$1] }
        }
    }
}
```

(which isn’t part of this pull request, but could be if there’s interest)