### PR TITLE
Fix code of fixture error for 32-bit devices

### DIFF
--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -98,8 +98,8 @@ final class ResultTests: XCTestCase {
 // MARK: - Fixtures
 
 let success = Result<String, NSError>.Success("success")
-let error = NSError(domain: "com.antitypical.Result", code: 0x01234567, userInfo: nil)
-let error2 = NSError(domain: "com.antitypical.Result", code: 0x12345678, userInfo: nil)
+let error = NSError(domain: "com.antitypical.Result", code: 1, userInfo: nil)
+let error2 = NSError(domain: "com.antitypical.Result", code: 2, userInfo: nil)
 let failure = Result<String, NSError>.Failure(error)
 let failure2 = Result<String, NSError>.Failure(error2)
 

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -98,7 +98,7 @@ final class ResultTests: XCTestCase {
 // MARK: - Fixtures
 
 let success = Result<String, NSError>.Success("success")
-let error = NSError(domain: "com.antitypical.Result", code: 0xdeadbeef, userInfo: nil)
+let error = NSError(domain: "com.antitypical.Result", code: 0x01234567, userInfo: nil)
 let error2 = NSError(domain: "com.antitypical.Result", code: 0x12345678, userInfo: nil)
 let failure = Result<String, NSError>.Failure(error)
 let failure2 = Result<String, NSError>.Failure(error2)


### PR DESCRIPTION
Replaces `0xdeadbeef` in test code with `0x01234567`.
`0xdeadbeef ` causes following build error on 32-bit devices.

```
ResultTests/ResultTests.swift:101:61: error: integer literal '3735928559' overflows when stored into 'Int'
let error = NSError(domain: "com.antitypical.Result", code: 0xdeadbeef, userInfo: nil)
```

See https://travis-ci.org/ishkawa/Result/builds/83435179 for the full content of xcodebuild log.