### PR TITLE
Add <^> (fmap) & <*> (ap) for applicative style support.

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -181,6 +181,26 @@ public func `try`(function: String = __FUNCTION__, file: String = __FILE__, line
 
 // MARK: - Operators
 
+infix operator <^> {
+	associativity left
+	precedence 140
+}
+
+/// fmap
+public func <^> <T, U, Error> (@noescape transform: T -> U, result: Result<T, Error>) -> Result<U, Error> {
+	return result.map(transform)
+}
+
+infix operator <*> {
+	associativity left
+	precedence 140
+}
+
+/// ap
+public func <*> <T, U, Error> (transform: Result<T -> U, Error>, @autoclosure result: () -> Result<T, Error>) -> Result<U, Error> {
+	return transform.flatMap { f in result().map(f) }
+}
+
 infix operator >>- {
 	// Left-associativity so that chaining works like you’d expect, and for consistency with Haskell, Runes, swiftz, etc.
 	associativity left

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -92,6 +92,61 @@ final class ResultTests: XCTestCase {
 		let resultFailureRight = success &&& failure2
 		XCTAssert(resultFailureRight.error == error2)
 	}
+	
+	// MARK: Functor, Applicative, Monad
+	
+	func testFunctor() {
+		let result1 = { $0.characters.count } <^> success
+		XCTAssertTrue(result1 == .Success(7))
+		
+		let result2 = { $0.characters.count } <^> failure
+		XCTAssertTrue(result2 == .Failure(error))
+	}
+	
+	func testApplicative() {
+		let result1 = .Success({ $0.characters.count }) <*> success
+		XCTAssertTrue(result1 == .Success(7))
+		
+		let result2 = .Success({ $0.characters.count }) <*> failure
+		XCTAssertTrue(result2 == .Failure(error))
+		
+		let result3: Result<Int, NSError> = .Failure(error) <*> success
+		XCTAssertTrue(result3 == .Failure(error))
+		
+		let result4: Result<Int, NSError> = .Failure(error) <*> failure
+		XCTAssertTrue(result4 == .Failure(error))
+	}
+	
+	func testApplicativeStyle() {
+		let f: Int -> Int -> Int = { x in { y in x + y } }
+		
+		let result1: Result<Int, NSError> = f <^> .Success(1) <*> .Success(2)
+		XCTAssertTrue(result1 == .Success(3))
+		
+		let result2: Result<Int, NSError> = f <^> .Success(1) <*> .Failure(error2)
+		XCTAssertTrue(result2 == .Failure(error2))
+		
+		let result3: Result<Int, NSError> = f <^> .Failure(error) <*> .Success(2)
+		XCTAssertTrue(result3 == .Failure(error))
+		
+		let result4: Result<Int, NSError> = f <^> .Failure(error) <*> .Failure(error2)
+		XCTAssertTrue(result4 == .Failure(error))
+	}
+	
+	func testMonad() {
+		let result1 = success >>- { .Success($0.characters.count) }
+		XCTAssertTrue(result1 == .Success(7))
+		
+		let result2 = success >>- { _ in Result<Int, NSError>.Failure(error) }
+		XCTAssertTrue(result2 == .Failure(error))
+		
+		let result3 = failure >>- { .Success($0.characters.count) }
+		XCTAssertTrue(result3 == .Failure(error))
+		
+		let result4 = failure >>- { _ in Result<Int, NSError>.Failure(error) }
+		XCTAssertTrue(result4 == .Failure(error))
+	}
+
 }
 
 


### PR DESCRIPTION
It will be nice if we can add Haskell's `fmap` and `ap` to support applicative style
as https://github.com/thoughtbot/Argo 's `Decoded<T>` type can do.