### PR TITLE
Adding tvOS as a deployment target in the podspec

### DIFF
--- a/Result.podspec
+++ b/Result.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
 end


### PR DESCRIPTION
A few hours ago I pushed the 0.6.0-beta.5 release to CocoaPods. Unfortunately, I forgot to add the appropriate deployment target to the podspec. As a result, the CocoaPods release is not compatible with tvOS. Sorry about that :disappointed: 

This PR contains the change I should have made. Please let me know if you think this is complete. And let me know how you think we should fix this release-wise. We could make a 0.6.0-beta.5b, or should we wait for 0.6.0-beta.6?