### PR TITLE
Lint the podspec during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ osx_image: xcode7.1
 script:
   - xcodebuild test -scheme Result-iOS -sdk iphonesimulator
   - xcodebuild test -scheme Result-Mac
+  - pod lib lint
 
 notifications:
   email: false


### PR DESCRIPTION
To ensure it stays valid.