### PR TITLE
Add a `materialize()` overload without autoclosure

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -146,6 +146,10 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 
 // MARK: - Derive result from failable closure
 
+public func materialize<T>(f: () throws -> T) -> Result<T, NSError> {
+	return materialize(try f())
+}
+
 public func materialize<T>(@autoclosure f: () throws -> T) -> Result<T, NSError> {
 	do {
 		return .Success(try f())

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -47,6 +47,22 @@ final class ResultTests: XCTestCase {
 		XCTAssert(result.error == error)
 	}
 
+	func testMaterializeProducesSuccesses() {
+		let result1 = materialize(try tryIsSuccess("success"))
+		XCTAssert(result1 == success)
+
+		let result2 = materialize { try tryIsSuccess("success") }
+		XCTAssert(result2 == success)
+	}
+
+	func testMaterializeProducesFailures() {
+		let result1 = materialize(try tryIsSuccess(nil))
+		XCTAssert(result1.error == error)
+
+		let result2 = materialize { try tryIsSuccess(nil) }
+		XCTAssert(result2.error == error)
+	}
+
 	// MARK: Cocoa API idioms
 
 	func testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference() {


### PR DESCRIPTION
We can't use autoclosure one with explicit (trailing) closure. :bow: 