### PR TITLE
Add tryMap. Like flatMap but for Swift2 error handling. 

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -146,7 +146,7 @@ public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Res
 
 // MARK: - Derive result from failable closure
 
-public func materialize<T>(f: () throws -> T) -> Result<T, NSError> {
+public func materialize<T>(@noescape f: () throws -> T) -> Result<T, NSError> {
 	return materialize(try f())
 }
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -200,5 +200,11 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 	return result.flatMap(transform)
 }
 
+/// Returns a new Result by mapping `Success`es’ values using `transform`, or wrapping errors thrown as `Failure`s’.
+///
+/// This is a synonym for `tryMap`.
+public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T throws -> U) -> Result<U, Error> {
+    return result.tryMap(transform)
+}
 
 import Foundation

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -51,6 +51,18 @@ public extension ResultType {
 			ifFailure: Result<U, Error>.Failure)
 	}
 	
+	/// Returns a new Result by mapping `Success`es’ values using `transform`, or wrapping errors thrown as `Failure`s’.
+	public func tryMap<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
+        return flatMap { value in
+            do {
+                return .Success(try transform(value))
+            }
+            catch {
+                return .Failure(error as! Error)
+            }
+        }
+    }
+
 	/// Returns a new Result by mapping `Failure`'s values using `transform`, or re-wrapping `Success`es’ values.
 	public func mapError<Error2>(@noescape transform: Error -> Error2) -> Result<Value, Error2> {
 		return flatMapError { .Failure(transform($0)) }

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -89,6 +89,16 @@ final class ResultTests: XCTestCase {
 		XCTAssertNil(result.error)
 	}
 
+	func testTryMapProducesSuccess() {
+		let result = success.tryMap(tryIsSuccess)
+		XCTAssert(result == success)
+	}
+
+	func testTryMapProducesFailure() {
+		let result = Result<String, NSError>.Success("fail").tryMap(tryIsSuccess)
+		XCTAssert(result == failure)
+	}
+
 	// MARK: Operators
 
 	func testConjunctionOperator() {
@@ -132,7 +142,7 @@ func attempt<T>(value: T, succeed: Bool, error: NSErrorPointer) -> T? {
 }
 
 func tryIsSuccess(text: String?) throws -> String {
-	guard let text = text else {
+	guard let text = text where text == "success" else {
 		throw error
 	}
 	


### PR DESCRIPTION
The tryMap function allows code that throws to be more easily wrapped. 