### PR TITLE
Add bimap method

### DIFF
--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -65,7 +65,10 @@ public extension ResultProtocol {
 
 	/// Returns a new Result by mapping `Success`es’ values using `success`, and by mapping `Failure`'s values using `failure`.
 	func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2> {
-		return self.map(success).mapError(failure)
+		return analysis(
+			ifSuccess: { .success(success($0)) },
+			ifFailure: { .failure(failure($0)) }
+		)
 	}
 }
 

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -62,6 +62,11 @@ public extension ResultProtocol {
 			ifSuccess: Result<Value, Error2>.success,
 			ifFailure: transform)
 	}
+
+	/// Returns a new Result by mapping `Success`es’ values using `success`, and by mapping `Failure`'s values using `failure`.
+	func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2> {
+		return self.map(success).mapError(failure)
+	}
 }
 
 public extension ResultProtocol {

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -17,6 +17,19 @@ final class ResultTests: XCTestCase {
 		XCTAssert(Result(nil, failWith: error) == failure)
 	}
 
+	func testBimapTransformsSuccesses() {
+		XCTAssertEqual(success.bimap(
+			success: { $0.characters.count },
+			failure: { $0 }
+		) ?? 0, 7)
+	}
+
+	func testBimapTransformsFailures() {
+		XCTAssert(failure.bimap(
+			success: { $0 },
+			failure: { _ in error2 }
+		) == failure2)
+	}
 
 	// MARK: Errors
 


### PR DESCRIPTION
To make it easier to go from `Result<A, B>` to `Result<C, D>`. Instead of doing:

```
result.analysis(
    ifSuccess: { .Success(ValueThatUses($0)) },
    ifFailure: { .Failure(.Other($0)) })
```

or: 

```
switch result {
case .Success(let value): return .Success(ValueThatUses(value))
case .Failure(let error): return .Failure(.Other(error))
}
```

one can do:

```
result.bimap(success: valueThatUses, error: .other)
```
