### PR TITLE
Add a version of `map` that converts thrown errors to `Failure`s.

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -200,6 +200,9 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 	return result.flatMap(transform)
 }
 
+
+// MARK: - ErrorTypeConvertible conformance
+
 /// Make NSError conform to ErrorTypeConvertible
 extension NSError: ErrorTypeConvertible {
 	public static func errorFromErrorType(error: ErrorType) -> NSError {

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -200,5 +200,12 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 	return result.flatMap(transform)
 }
 
+/// Make NSError conform to ErrorTypeConvertible
+extension NSError: ErrorTypeConvertible {
+	public static func errorFromErrorType(error: ErrorType) -> NSError {
+		return error as NSError
+	}
+}
+
 
 import Foundation

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -64,6 +64,26 @@ public extension ResultType {
 	}
 }
 
+/// Protocol used to constrain a version of `map` for `transform`s that throw.
+public protocol ErrorTypeConvertible: ErrorType {
+	typealias ConvertibleType = Self
+	static func errorFromErrorType(error:ErrorType) -> ConvertibleType
+}
+
+public extension ResultType where Error: ErrorTypeConvertible {
+
+	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
+	public func map<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
+		return flatMap { value in
+			do {
+				return .Success(try transform(value))
+			} catch {
+				return .Failure(Error.errorFromErrorType(error) as! Error)
+			}
+		}
+	}
+}
+
 // MARK: - Operators
 
 infix operator &&& {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -79,9 +79,8 @@ public extension ResultType where Error: ErrorTypeConvertible {
 				return .Success(try transform(value))
 			}
 			catch {
-				guard let convertedError = Error.errorFromErrorType(error) as? Error else {
-					fatalError("Unable to convert error type '\(error.dynamicType)' to type '\(Error.self)'")
-				}
+				let convertedError = Error.errorFromErrorType(error) as! Error
+				// Revisit this in a future version of Swift. https://twitter.com/jckarter/status/672931114944696321
 				return .Failure(convertedError)
 			}
 		}

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -67,7 +67,7 @@ public extension ResultType {
 /// Protocol used to constrain a version of `map` for `transform`s that throw.
 public protocol ErrorTypeConvertible: ErrorType {
 	typealias ConvertibleType = Self
-	static func errorFromErrorType(error:ErrorType) -> ConvertibleType
+	static func errorFromErrorType(error: ErrorType) -> ConvertibleType
 }
 
 public extension ResultType where Error: ErrorTypeConvertible {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -77,8 +77,12 @@ public extension ResultType where Error: ErrorTypeConvertible {
 		return flatMap { value in
 			do {
 				return .Success(try transform(value))
-			} catch {
-				return .Failure(Error.errorFromErrorType(error) as! Error)
+			}
+			catch {
+				guard let convertedError = Error.errorFromErrorType(error) as? Error else {
+					fatalError("Unable to convert error type '\(error.dynamicType)' to type '\(Error.self)'")
+				}
+				return .Failure(convertedError)
 			}
 		}
 	}

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -64,7 +64,7 @@ public extension ResultType {
 	}
 }
 
-/// Protocol used to constrain a version of `map` for `transform`s that throw.
+/// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
 public protocol ErrorTypeConvertible: ErrorType {
 	typealias ConvertibleType = Self
 	static func errorFromErrorType(error: ErrorType) -> ConvertibleType
@@ -73,7 +73,7 @@ public protocol ErrorTypeConvertible: ErrorType {
 public extension ResultType where Error: ErrorTypeConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
-	public func map<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
+	public func tryMap<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
 		return flatMap { value in
 			do {
 				return .Success(try transform(value))

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -90,12 +90,12 @@ final class ResultTests: XCTestCase {
 	}
 
 	func testTryMapProducesSuccess() {
-		let result = success.map(tryIsSuccess)
+		let result = success.tryMap(tryIsSuccess)
 		XCTAssert(result == success)
 	}
 
 	func testTryMapProducesFailure() {
-		let result = Result<String, NSError>.Success("fail").map(tryIsSuccess)
+		let result = Result<String, NSError>.Success("fail").tryMap(tryIsSuccess)
 		XCTAssert(result == failure)
 	}
 

--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -89,6 +89,16 @@ final class ResultTests: XCTestCase {
 		XCTAssertNil(result.error)
 	}
 
+	func testTryMapProducesSuccess() {
+		let result = success.map(tryIsSuccess)
+		XCTAssert(result == success)
+	}
+
+	func testTryMapProducesFailure() {
+		let result = Result<String, NSError>.Success("fail").map(tryIsSuccess)
+		XCTAssert(result == failure)
+	}
+
 	// MARK: Operators
 
 	func testConjunctionOperator() {
@@ -132,7 +142,7 @@ func attempt<T>(value: T, succeed: Bool, error: NSErrorPointer) -> T? {
 }
 
 func tryIsSuccess(text: String?) throws -> String {
-	guard let text = text else {
+	guard let text = text where text == "success" else {
 		throw error
 	}
 	


### PR DESCRIPTION
Add a variant of `map` that handles `transform`s that throw errors and converts errors to `Failure`s.
This `map` is constrained to `Result`s with `Error` types that can be constructed from arbitrary `ErrorType`s.
