### PR TITLE
Add 'Reference Status' from versioneye to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/antitypical/Result.svg?branch=master)](https://travis-ci.org/antitypical/Result)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Result.svg)](https://cocoapods.org/)
+[![Reference Status](https://www.versioneye.com/objective-c/result/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/result/references)
 
 This is a Swift µframework providing `Result<Value, Error>`.
 


### PR DESCRIPTION
Result is µframework and I expect that more people will use it instead of reinvent the wheel (like I see in some repository)
Versioneye give you the number of project that use your project as dependency like ReactiveCocoa, BrightFutures, ...
https://www.versioneye.com/objective-c/result/references
https://www.versioneye.com/objective-c/result/
![badge](https://www.versioneye.com/objective-c/result/reference_badge.svg?style=flat)