### PR TITLE
Adding mapping over Results containing collections

### DIFF
--- a/ResultTests/ResultTests.swift
+++ b/ResultTests/ResultTests.swift
@@ -16,6 +16,16 @@ final class ResultTests: XCTestCase {
 	func testInitOptionalFailure() {
 		XCTAssert(Result(nil, failWith: error) == failure)
 	}
+	
+	// MARK: Collections
+	
+	func testCollectionMapTransformsSuccesses() {
+		XCTAssertEqual(successCollection.map { $0.characters.count } ?? [], [7, 14])
+	}
+	
+	func testCollectionMapRewrapsFailures() {
+		XCTAssertEqual(failureCollection.map { $0.characters.count } ?? [], [])
+	}
 
 
 	// MARK: Errors
@@ -114,10 +124,12 @@ final class ResultTests: XCTestCase {
 // MARK: - Fixtures
 
 let success = Result<String, NSError>.Success("success")
+let successCollection = Result<[String], NSError>.Success(["success", "anotherSuccess"])
 let error = NSError(domain: "com.antitypical.Result", code: 1, userInfo: nil)
 let error2 = NSError(domain: "com.antitypical.Result", code: 2, userInfo: nil)
 let failure = Result<String, NSError>.Failure(error)
 let failure2 = Result<String, NSError>.Failure(error2)
+let failureCollection = Result<[String], NSError>.Failure(error)
 
 
 // MARK: - Helpers


### PR DESCRIPTION
Usecase:

```
let foo = self
	.iLoveResults()
	.flatMap(butAreTheseResultsGoodEnough)
	.flatMap { $0.count > 3 ? .Success($0) : .Failure(someError) } //and are there enough of them?

func iLoveResults() -> Result<[String], NSError> {
	return .Success(["aFineResult", "anotherExcellentResult", "aBadResult"])
}

func butAreTheseResultsGoodEnough(result: String) -> Result<String, NSError> {
	return (result.characters.count > 10 ? .Success(result) : .Failure(someError))
}
```

If I've got a `Result` which (on `.Success`) contains a Collection, I'd like to have the option to handle that success as a whole, or item-by-item with minimal boilerplate. In the example above, the first `flatMap` deals with the results item-by-item, the second as a whole collection. The `flatMap` used in each case is inferred from the context.