### PR TITLE
Update version in podspec to 1.0.1

### DIFF
--- a/Result.podspec
+++ b/Result.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Result'
-  s.version      = '1.0.0'
+  s.version      = '1.0.1'
   s.summary      = 'Swift type modelling the success/failure of arbitrary operations'
 
   s.homepage     = 'https://github.com/antitypical/Result'


### PR DESCRIPTION
We forgot to do this for the 1.0.1 release. The change is quite straight forward, but to make sure I'm not forgetting anything (like last time), I'd like a second pair of :eyes: to :+1:. Thanks!