### PR TITLE
Run `swift test` on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       language: objective-c
     - script:
         - swift build
+        - swift test
       env: JOB=Linux
       sudo: required
       dist: trusty

--- a/Tests/Result/ResultTests.swift
+++ b/Tests/Result/ResultTests.swift
@@ -20,8 +20,6 @@ final class ResultTests: XCTestCase {
 
 	// MARK: Errors
 
-	#if !os(Linux)
-
 	func testErrorsIncludeTheSourceFile() {
 		let file = __FILE__
 		XCTAssert(Result<(), NSError>.error().file == file)
@@ -37,8 +35,6 @@ final class ResultTests: XCTestCase {
 		XCTAssert(Result<(), NSError>.error().function == function)
 	}
 
-	#endif
-
 	// MARK: Try - Catch
 	
 	func testTryCatchProducesSuccesses() {
@@ -47,8 +43,13 @@ final class ResultTests: XCTestCase {
 	}
 	
 	func testTryCatchProducesFailures() {
-		let result: Result<String, NSError> = Result(try tryIsSuccess(nil))
-		XCTAssert(result.error == error)
+		#if os(Linux)
+			/// FIXME: skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.
+			print("Test Case `\(__FUNCTION__)` skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.")
+		#else
+			let result: Result<String, NSError> = Result(try tryIsSuccess(nil))
+			XCTAssert(result.error == error)
+		#endif
 	}
 
 	func testTryCatchWithFunctionProducesSuccesses() {
@@ -59,10 +60,15 @@ final class ResultTests: XCTestCase {
 	}
 
 	func testTryCatchWithFunctionCatchProducesFailures() {
-		let function = { try tryIsSuccess(nil) }
+		#if os(Linux)
+			/// FIXME: skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.
+			print("Test Case `\(__FUNCTION__)` skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.")
+		#else
+			let function = { try tryIsSuccess(nil) }
 
-		let result: Result<String, NSError> = Result(attempt: function)
-		XCTAssert(result.error == error)
+			let result: Result<String, NSError> = Result(attempt: function)
+			XCTAssert(result.error == error)
+		#endif
 	}
 
 	func testMaterializeProducesSuccesses() {
@@ -74,11 +80,16 @@ final class ResultTests: XCTestCase {
 	}
 
 	func testMaterializeProducesFailures() {
-		let result1 = materialize(try tryIsSuccess(nil))
-		XCTAssert(result1.error == error)
+		#if os(Linux)
+			/// FIXME: skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.
+			print("Test Case `\(__FUNCTION__)` skipped on Linux because of crash with swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.")
+		#else
+			let result1 = materialize(try tryIsSuccess(nil))
+			XCTAssert(result1.error == error)
 
-		let result2 = materialize { try tryIsSuccess(nil) }
-		XCTAssert(result2.error == error)
+			let result2 = materialize { try tryIsSuccess(nil) }
+			XCTAssert(result2.error == error)
+		#endif
 	}
 
 	// MARK: Cocoa API idioms
@@ -175,23 +186,19 @@ func tryIsSuccess(text: String?) throws -> String {
 	return text
 }
 
-#if !os(Linux)
-
 extension NSError {
 	var function: String? {
-		return userInfo[Result<(), NSError>.functionKey as NSString] as? String
+		return userInfo[Result<(), NSError>.functionKey] as? String
 	}
 	
 	var file: String? {
-		return userInfo[Result<(), NSError>.fileKey as NSString] as? String
+		return userInfo[Result<(), NSError>.fileKey] as? String
 	}
 
 	var line: Int? {
-		return userInfo[Result<(), NSError>.lineKey as NSString] as? Int
+		return userInfo[Result<(), NSError>.lineKey] as? Int
 	}
 }
-
-#endif
 
 #if os(Linux)
 
@@ -202,9 +209,9 @@ extension ResultTests: XCTestCaseProvider {
 			("testMapRewrapsFailures", testMapRewrapsFailures),
 			("testInitOptionalSuccess", testInitOptionalSuccess),
 			("testInitOptionalFailure", testInitOptionalFailure),
-//			("testErrorsIncludeTheSourceFile", testErrorsIncludeTheSourceFile),
-//			("testErrorsIncludeTheSourceLine", testErrorsIncludeTheSourceLine),
-//			("testErrorsIncludeTheCallingFunction", testErrorsIncludeTheCallingFunction),
+			("testErrorsIncludeTheSourceFile", testErrorsIncludeTheSourceFile),
+			("testErrorsIncludeTheSourceLine", testErrorsIncludeTheSourceLine),
+			("testErrorsIncludeTheCallingFunction", testErrorsIncludeTheCallingFunction),
 			("testTryCatchProducesSuccesses", testTryCatchProducesSuccesses),
 			("testTryCatchProducesFailures", testTryCatchProducesFailures),
 			("testTryCatchWithFunctionProducesSuccesses", testTryCatchWithFunctionProducesSuccesses),


### PR DESCRIPTION
- Use `#if` only on codes that can't be compiled.
- Add printing message to crashing test on Linux and run them.