### PR TITLE
Reconsider ErrorTypeConvertible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,10 @@ matrix:
       before_install:
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
         - cd ..
-        - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-03-16-a
+        - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-03-24-a
         - wget https://swift.org/builds/development/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz
         - tar xzf $SWIFT_VERSION-ubuntu14.04.tar.gz
         - export PATH="${PWD}/${SWIFT_VERSION}-ubuntu14.04/usr/bin:${PATH}"
-        - export LD_LIBRARY_PATH="${PWD}/${SWIFT_VERSION}-ubuntu14.04/usr/lib/swift/linux/:$LD_LIBRARY_PATH"
         - cd Result
 notifications:
   email: false

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -218,18 +218,11 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 
 #if !os(Linux)
 	
-	public extension ErrorTypeConvertible where Self : NSError {
-		public func force<T>() -> T {
-			return self as! T
-		}
+extension NSError: ErrorTypeConvertible {
+	public static func errorFromErrorType(error: ResultErrorType) -> NSError {
+		return error as NSError
 	}
-	
-	extension NSError: ErrorTypeConvertible {
-		public static func errorFromErrorType(error: ResultErrorType) -> Self {
-			let e = error as NSError
-			return e.force()
-		}
-	}
+}
 
 #endif
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -219,8 +219,12 @@ public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T 
 #if !os(Linux)
 	
 extension NSError: ErrorTypeConvertible {
-	public static func errorFromErrorType(error: ResultErrorType) -> NSError {
-		return error as NSError
+	public static func errorFromErrorType(error: ResultErrorType) -> Self {
+		func cast<T: NSError>(error: ResultErrorType) -> T {
+			return error as! T
+		}
+
+		return cast(error)
 	}
 }
 

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -72,11 +72,10 @@ public extension ResultType {
 
 /// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
 public protocol ErrorTypeConvertible: ResultErrorType {
-	associatedtype ConvertibleType = Self
-	static func errorFromErrorType(error: ResultErrorType) -> ConvertibleType
+	static func errorFromErrorType(error: ResultErrorType) -> Self
 }
 
-public extension ResultType where Error: ErrorTypeConvertible, Error.ConvertibleType == Error {
+public extension ResultType where Error: ErrorTypeConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -73,10 +73,10 @@ public extension ResultType {
 /// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
 public protocol ErrorTypeConvertible: ResultErrorType {
 	associatedtype ConvertibleType = Self
-	static func errorFromErrorType(error: ResultErrorType) -> Self
+	static func errorFromErrorType(error: ResultErrorType) -> ConvertibleType
 }
 
-public extension ResultType where Error: ErrorTypeConvertible {
+public extension ResultType where Error: ErrorTypeConvertible, Error.ConvertibleType == Error {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
@@ -85,7 +85,7 @@ public extension ResultType where Error: ErrorTypeConvertible {
 				return .Success(try transform(value))
 			}
 			catch {
-				let convertedError = Error.errorFromErrorType(error)// as! Error, not deleting it as things might change
+				let convertedError = Error.errorFromErrorType(error)
 				// Revisit this in a future version of Swift. https://twitter.com/jckarter/status/672931114944696321
 				return .Failure(convertedError)
 			}


### PR DESCRIPTION
This was changed in https://github.com/antitypical/Result/pull/141. But the current form does not looks correct since the `ConvertibleType` associated type is not used in any method signature.

This change ~~brings back the original definition~~ removes `ConvertibleType` from `ErrorTypeConvertible` and worked well for both Swift 2.2 on OS X and swift-DEVELOPMENT-SNAPSHOT-2016-03-24-a on Linux.