### PR TITLE
Warn when result is unused.

### DIFF
--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -46,11 +46,13 @@ public extension ResultType {
 	}
 
 	/// Returns a new Result by mapping `Success`es’ values using `transform`, or re-wrapping `Failure`s’ errors.
+	@warn_unused_result
 	public func map<U>(@noescape transform: Value -> U) -> Result<U, Error> {
 		return flatMap { .Success(transform($0)) }
 	}
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
+	@warn_unused_result
 	public func flatMap<U>(@noescape transform: Value -> Result<U, Error>) -> Result<U, Error> {
 		return analysis(
 			ifSuccess: transform,
@@ -58,11 +60,13 @@ public extension ResultType {
 	}
 	
 	/// Returns a new Result by mapping `Failure`'s values using `transform`, or re-wrapping `Success`es’ values.
+	@warn_unused_result
 	public func mapError<Error2>(@noescape transform: Error -> Error2) -> Result<Value, Error2> {
 		return flatMapError { .Failure(transform($0)) }
 	}
 	
 	/// Returns the result of applying `transform` to `Failure`’s errors, or re-wrapping `Success`es’ values.
+	@warn_unused_result
 	public func flatMapError<Error2>(@noescape transform: Error -> Result<Value, Error2>) -> Result<Value, Error2> {
 		return analysis(
 			ifSuccess: Result<Value, Error2>.Success,
@@ -78,6 +82,7 @@ public protocol ErrorTypeConvertible: ResultErrorType {
 public extension ResultType where Error: ErrorTypeConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
+	@warn_unused_result
 	public func tryMap<U>(@noescape transform: Value throws -> U) -> Result<U, Error> {
 		return flatMap { value in
 			do {


### PR DESCRIPTION
As a follow-up for #150, and to help with #151, I've annotated the API with `@warn_unused_result`. With this change the following line will trigger a warning:

```swift
doOperation().map { string in
    print(string)
}
```

If the result value is not used later on, it will also trigger a warning:
```swift
let result = doOperation().flatMap(doOtherOperation)
```