### PR TITLE
Redefine functions in terms of ResultType

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -139,17 +139,6 @@ public enum Result<T, Error: ResultErrorType>: ResultType, CustomStringConvertib
 	}
 }
 
-
-/// Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.
-public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> T) -> T {
-	return left.recover(right())
-}
-
-/// Returns `left` if it is a `Success`es, or `right` otherwise. Short-circuits.
-public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> Result<T, Error>) -> Result<T, Error> {
-	return left.recoverWith(right())
-}
-
 // MARK: - Derive result from failable closure
 
 #if swift(>=3)

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -71,34 +71,6 @@ public enum Result<T, Error: ResultErrorType>: ResultType, CustomStringConvertib
 	}
 #endif
 
-	// MARK: Higher-order functions
-	
-	/// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
-#if swift(>=3)
-	public func recover(@autoclosure _ value: () -> T) -> T {
-		return self.value ?? value()
-	}
-#else
-	public func recover(@autoclosure value: () -> T) -> T {
-		return self.value ?? value()
-	}
-#endif
-	
-	/// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
-#if swift(>=3)
-	public func recoverWith(@autoclosure _ result: () -> Result<T,Error>) -> Result<T,Error> {
-		return analysis(
-			ifSuccess: { _ in self },
-			ifFailure: { _ in result() })
-	}
-#else
-	public func recoverWith(@autoclosure result: () -> Result<T,Error>) -> Result<T,Error> {
-		return analysis(
-			ifSuccess: { _ in self },
-			ifFailure: { _ in result() })
-	}
-#endif
-
 	// MARK: Errors
 
 	/// The domain for errors constructed by Result.

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -211,24 +211,6 @@ public func `try`(function: String = #function, file: String = #file, line: Int 
 
 #endif
 
-// MARK: - Operators
-
-infix operator >>- {
-	// Left-associativity so that chaining works like you’d expect, and for consistency with Haskell, Runes, swiftz, etc.
-	associativity left
-
-	// Higher precedence than function application, but lower than function composition.
-	precedence 100
-}
-
-/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
-///
-/// This is a synonym for `flatMap`.
-public func >>- <T, U, Error> (result: Result<T, Error>, @noescape transform: T -> Result<U, Error>) -> Result<U, Error> {
-	return result.flatMap(transform)
-}
-
-
 // MARK: - ErrorTypeConvertible conformance
 
 #if !os(Linux)

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -168,22 +168,6 @@ public enum Result<T, Error: ResultErrorType>: ResultType, CustomStringConvertib
 }
 
 
-/// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
-public func == <T: Equatable, Error: Equatable> (left: Result<T, Error>, right: Result<T, Error>) -> Bool {
-	if let left = left.value, right = right.value {
-		return left == right
-	} else if let left = left.error, right = right.error {
-		return left == right
-	}
-	return false
-}
-
-/// Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.
-public func != <T: Equatable, Error: Equatable> (left: Result<T, Error>, right: Result<T, Error>) -> Bool {
-	return !(left == right)
-}
-
-
 /// Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.
 public func ?? <T, Error> (left: Result<T, Error>, @autoclosure right: () -> T) -> T {
 	return left.recover(right())

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -167,3 +167,18 @@ infix operator &&& {
 public func &&& <L: ResultType, R: ResultType where L.Error == R.Error> (left: L, @autoclosure right: () -> R) -> Result<(L.Value, R.Value), L.Error> {
 	return left.flatMap { left in right().map { right in (left, right) } }
 }
+
+/// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
+public func == <T: ResultType where T.Value: Equatable, T.Error: Equatable> (left: T, right: T) -> Bool {
+	if let left = left.value, right = right.value {
+		return left == right
+	} else if let left = left.error, right = right.error {
+		return left == right
+	}
+	return false
+}
+
+/// Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.
+public func != <T: ResultType where T.Value: Equatable, T.Error: Equatable> (left: T, right: T) -> Bool {
+	return !(left == right)
+}

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -110,6 +110,37 @@ public extension ResultType {
 #endif
 }
 
+public extension ResultType {
+
+	// MARK: Higher-order functions
+
+	/// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
+#if swift(>=3)
+	public func recover(@autoclosure _ value: () -> Value) -> Value {
+		return self.value ?? value()
+	}
+#else
+	public func recover(@autoclosure value: () -> Value) -> Value {
+		return self.value ?? value()
+	}
+#endif
+
+	/// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
+#if swift(>=3)
+	public func recoverWith(@autoclosure _ result: () -> Self) -> Self {
+		return analysis(
+			ifSuccess: { _ in self },
+			ifFailure: { _ in result() })
+	}
+#else
+	public func recoverWith(@autoclosure result: () -> Self) -> Self {
+		return analysis(
+			ifSuccess: { _ in self },
+			ifFailure: { _ in result() })
+	}
+#endif
+}
+
 /// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
 public protocol ErrorTypeConvertible: ResultErrorType {
 #if swift(>=3)

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -199,6 +199,21 @@ public func &&& <L: ResultType, R: ResultType where L.Error == R.Error> (left: L
 	return left.flatMap { left in right().map { right in (left, right) } }
 }
 
+infix operator >>- {
+	// Left-associativity so that chaining works like you’d expect, and for consistency with Haskell, Runes, swiftz, etc.
+	associativity left
+
+	// Higher precedence than function application, but lower than function composition.
+	precedence 100
+}
+
+/// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
+///
+/// This is a synonym for `flatMap`.
+public func >>- <T: ResultType, U> (result: T, @noescape transform: T.Value -> Result<U, T.Error>) -> Result<U, T.Error> {
+	return result.flatMap(transform)
+}
+
 /// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
 public func == <T: ResultType where T.Value: Equatable, T.Error: Equatable> (left: T, right: T) -> Bool {
 	if let left = left.value, right = right.value {

--- a/Result/ResultType.swift
+++ b/Result/ResultType.swift
@@ -213,3 +213,13 @@ public func == <T: ResultType where T.Value: Equatable, T.Error: Equatable> (lef
 public func != <T: ResultType where T.Value: Equatable, T.Error: Equatable> (left: T, right: T) -> Bool {
 	return !(left == right)
 }
+
+/// Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.
+public func ?? <T: ResultType> (left: T, @autoclosure right: () -> T.Value) -> T.Value {
+	return left.recover(right())
+}
+
+/// Returns `left` if it is a `Success`es, or `right` otherwise. Short-circuits.
+public func ?? <T: ResultType> (left: T, @autoclosure right: () -> T) -> T {
+	return left.recoverWith(right())
+}

--- a/Tests/Result/ResultTests.swift
+++ b/Tests/Result/ResultTests.swift
@@ -92,6 +92,47 @@ final class ResultTests: XCTestCase {
 		#endif
 	}
 
+	// MARK: Recover
+
+	func testRecoverProducesLeftForLeftSuccess() {
+		let left = Result<String, NSError>.Success("left")
+		XCTAssertEqual(left.recover("right"), "left")
+	}
+
+	func testRecoverProducesRightForLeftFailure() {
+		struct Error: ResultErrorType {}
+
+		let left = Result<String, Error>.Failure(Error())
+		XCTAssertEqual(left.recover("right"), "right")
+	}
+
+	// MARK: Recover With
+
+	func testRecoverWithProducesLeftForLeftSuccess() {
+		let left = Result<String, NSError>.Success("left")
+		let right = Result<String, NSError>.Success("right")
+
+		XCTAssertEqual(left.recoverWith(right).value, "left")
+	}
+
+	func testRecoverWithProducesRightSuccessForLeftFailureAndRightSuccess() {
+		struct Error: ResultErrorType {}
+
+		let left = Result<String, Error>.Failure(Error())
+		let right = Result<String, Error>.Success("right")
+
+		XCTAssertEqual(left.recoverWith(right).value, "right")
+	}
+
+	func testRecoverWithProducesRightFailureForLeftFailureAndRightFailure() {
+		enum Error: ResultErrorType { case Left, Right }
+
+		let left = Result<String, Error>.Failure(.Left)
+		let right = Result<String, Error>.Failure(.Right)
+
+		XCTAssertEqual(left.recoverWith(right).error, .Right)
+	}
+
 	// MARK: Cocoa API idioms
 
 	#if !os(Linux)
@@ -240,6 +281,11 @@ extension ResultTests {
 			("testTryCatchWithFunctionCatchProducesFailures", testTryCatchWithFunctionCatchProducesFailures),
 			("testMaterializeProducesSuccesses", testMaterializeProducesSuccesses),
 			("testMaterializeProducesFailures", testMaterializeProducesFailures),
+			("testRecoverProducesLeftForLeftSuccess", testRecoverProducesLeftForLeftSuccess),
+			("testRecoverProducesRightForLeftFailure", testRecoverProducesRightForLeftFailure),
+			("testRecoverWithProducesLeftForLeftSuccess", testRecoverWithProducesLeftForLeftSuccess),
+			("testRecoverWithProducesRightSuccessForLeftFailureAndRightSuccess", testRecoverWithProducesRightSuccessForLeftFailureAndRightSuccess),
+			("testRecoverWithProducesRightFailureForLeftFailureAndRightFailure", testRecoverWithProducesRightFailureForLeftFailureAndRightFailure),
 //			("testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference", testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference),
 //			("testTryProducesFailuresForOptionalWithErrorReturnedByReference", testTryProducesFailuresForOptionalWithErrorReturnedByReference),
 //			("testTryProducesSuccessesForBooleanAPI", testTryProducesSuccessesForBooleanAPI),


### PR DESCRIPTION
This redefines the functions `recover`, `recoverWith`, `==`, `!=`, `??`, and `>>-` in terms of `ResultType`, allowing them to be used more generically. The operators only used functionality that was already available in `ResultType`, so the only changes are to the type declarations for the functions - the implementations are identical.