### PR TITLE
Update Info.plist and Result.podspec for 2.1.1 release

### DIFF
--- a/Result.podspec
+++ b/Result.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Result'
-  s.version      = '2.1.0'
+  s.version      = '2.1.1'
   s.summary      = 'Swift type modelling the success/failure of arbitrary operations'
 
   s.homepage     = 'https://github.com/antitypical/Result'

--- a/Result.podspec
+++ b/Result.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/antitypical/Result.git', :tag => s.version }
   s.source_files  = 'Result/*.swift'
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'

--- a/Result/Info.plist
+++ b/Result/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Result/Info.plist
+++ b/Tests/Result/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Updating plist files are done automatically by `agvtool new-marketing-version 2.1.1`.

I'm happy if someone of the existing owners of the `Result` trunk of CocoaPods would add me as an owner.