### PR TITLE
[Swift 2.3] Record Swift migration to suppress warning on Xcode 8

### DIFF
--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -401,17 +401,27 @@
 					57FCDE491BA280E000130C48 = {
 						LastSwiftMigration = 0800;
 					};
+					D03579991B2B788F005D26AE = {
+						LastSwiftMigration = 0800;
+					};
+					D03579A51B2B78A1005D26AE = {
+						LastSwiftMigration = 0800;
+					};
 					D45480561A9572F5009D7229 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D45480661A9572F5009D7229 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D454807C1A957361009D7229 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D45480861A957362009D7229 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};


### PR DESCRIPTION
I would cut the 2.1.3 once this is merged.