### PR TITLE
3.0.0-alpha.4 Podspec validation

### DIFF
--- a/Result.podspec
+++ b/Result.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Result'
-  s.version      = '3.0.0-alpha.1'
+  s.version      = '3.0.0-alpha.4'
   s.summary      = 'Swift type modelling the success/failure of arbitrary operations'
 
   s.homepage     = 'https://github.com/antitypical/Result'


### PR DESCRIPTION
Since 3.0.0-alpha.4 has been released on origin/master, the wrong tag is on the podspec

Just applying good "s.version" for pod fetching