### PR TITLE
Add type-erased `AnyError` for generic contexts

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -187,7 +187,7 @@ public enum NoError: Swift.Error { }
 
 /// A type-erased error which wraps an arbitrary error instance. This should be
 /// useful for generic contexts.
-public struct AnyError: Swift.Error, ErrorProtocolConvertible, Equatable, CustomStringConvertible {
+public struct AnyError: Swift.Error, ErrorProtocolConvertible, CustomStringConvertible {
 	/// The underlying error.
 	public let error: Swift.Error
 
@@ -200,11 +200,6 @@ public struct AnyError: Swift.Error, ErrorProtocolConvertible, Equatable, Custom
 			return anyError
 		}
 		return AnyError(error)
-	}
-
-	public static func ==(lhs: AnyError, rhs: AnyError) -> Bool {
-		return lhs.error._code == rhs.error._code
-			&& lhs.error._domain == rhs.error._domain
 	}
 
 	public var description: String {

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -185,7 +185,7 @@ public enum NoError: Swift.Error { }
 
 /// A type-erased error which wraps an arbitrary error instance. This should be
 /// useful for generic contexts.
-public struct AnyError: Swift.Error, ErrorProtocolConvertible, CustomStringConvertible {
+public struct AnyError: Swift.Error {
 	/// The underlying error.
 	public let error: Swift.Error
 
@@ -196,11 +196,15 @@ public struct AnyError: Swift.Error, ErrorProtocolConvertible, CustomStringConve
 			self.error = error
 		}
 	}
+}
 
+extension AnyError: ErrorProtocolConvertible {
 	public static func error(from error: Error) -> AnyError {
 		return AnyError(error)
 	}
+}
 
+extension AnyError: CustomStringConvertible {
 	public var description: String {
 		return String(describing: error)
 	}

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -115,8 +115,6 @@ public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError> {
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError> {
 	do {
 		return .success(try f())
-	} catch let error as AnyError {
-		return .failure(error)
 	} catch {
 		return .failure(AnyError(error))
 	}
@@ -192,13 +190,14 @@ public struct AnyError: Swift.Error, ErrorProtocolConvertible, CustomStringConve
 	public let error: Swift.Error
 
 	public init(_ error: Swift.Error) {
-		self.error = error
+		if let anyError = error as? AnyError {
+			self = anyError
+		} else {
+			self.error = error
+		}
 	}
 
 	public static func error(from error: Error) -> AnyError {
-		if let anyError = error as? AnyError {
-			return anyError
-		}
 		return AnyError(error)
 	}
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -122,12 +122,12 @@ public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyErr
 	}
 }
 
-@available(*, deprecated, message: "Use the overroad which returns `Result<T, AnyError>` instead")
+@available(*, deprecated, message: "Use the overload which returns `Result<T, AnyError>` instead")
 public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError> {
 	return materialize(try f())
 }
 
-@available(*, deprecated, message: "Use the overroad which returns `Result<T, AnyError>` instead")
+@available(*, deprecated, message: "Use the overload which returns `Result<T, AnyError>` instead")
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSError> {
 	do {
 		return .success(try f())

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -187,7 +187,7 @@ public enum NoError: Swift.Error { }
 
 /// A type-erased error which wraps an arbitrary error instance. This should be
 /// useful for generic contexts.
-public struct AnyError: Swift.Error, ErrorProtocolConvertible, Equatable {
+public struct AnyError: Swift.Error, ErrorProtocolConvertible, Equatable, CustomStringConvertible {
 	/// The underlying error.
 	public let error: Swift.Error
 
@@ -205,6 +205,10 @@ public struct AnyError: Swift.Error, ErrorProtocolConvertible, Equatable {
 	public static func ==(lhs: AnyError, rhs: AnyError) -> Bool {
 		return lhs.error._code == rhs.error._code
 			&& lhs.error._domain == rhs.error._domain
+	}
+
+	public var description: String {
+		return String(describing: error)
 	}
 }
 

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -193,6 +193,13 @@ let failure2 = Result<String, AnyError>.failure(error2)
 
 // MARK: - Helpers
 
+extension AnyError: Equatable {
+	public static func ==(lhs: AnyError, rhs: AnyError) -> Bool {
+		return lhs.error._code == rhs.error._code
+			&& lhs.error._domain == rhs.error._domain
+	}
+}
+
 #if !os(Linux)
 
 func attempt<T>(_ value: T, succeed: Bool, error: NSErrorPointer) -> T? {

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -38,71 +38,54 @@ final class ResultTests: XCTestCase {
 	// MARK: Try - Catch
 	
 	func testTryCatchProducesSuccesses() {
-		let result: Result<String, NSError> = Result(try tryIsSuccess("success"))
+		let result: Result<String, AnyError> = Result(try tryIsSuccess("success"))
 		XCTAssert(result == success)
 	}
 	
 	func testTryCatchProducesFailures() {
-		#if os(Linux)
-			/// FIXME: skipped on Linux because of crash with swift-3.0-PREVIEW-4.
-			print("Test Case `\(#function)` skipped on Linux because of crash with swift-3.0-PREVIEW-4.")
-		#else
-			let result: Result<String, NSError> = Result(try tryIsSuccess(nil))
-			XCTAssert(result.error == error)
-		#endif
+		let result: Result<String, AnyError> = Result(try tryIsSuccess(nil))
+		XCTAssert(result.error == error)
 	}
 
 	func testTryCatchWithFunctionProducesSuccesses() {
 		let function = { try tryIsSuccess("success") }
 
-		let result: Result<String, NSError> = Result(attempt: function)
+		let result: Result<String, AnyError> = Result(attempt: function)
 		XCTAssert(result == success)
 	}
 
 	func testTryCatchWithFunctionCatchProducesFailures() {
-		#if os(Linux)
-			/// FIXME: skipped on Linux because of crash with swift-3.0-PREVIEW-4.
-			print("Test Case `\(#function)` skipped on Linux because of crash with swift-3.0-PREVIEW-4.")
-		#else
-			let function = { try tryIsSuccess(nil) }
+		let function = { try tryIsSuccess(nil) }
 
-			let result: Result<String, NSError> = Result(attempt: function)
-			XCTAssert(result.error == error)
-		#endif
+		let result: Result<String, AnyError> = Result(attempt: function)
+		XCTAssert(result.error == error)
 	}
 
 	func testMaterializeProducesSuccesses() {
-		let result1 = materialize(try tryIsSuccess("success"))
+		let result1: Result<String, AnyError> = materialize(try tryIsSuccess("success"))
 		XCTAssert(result1 == success)
 
-		let result2: Result<String, NSError> = materialize { try tryIsSuccess("success") }
+		let result2: Result<String, AnyError> = materialize { try tryIsSuccess("success") }
 		XCTAssert(result2 == success)
 	}
 
 	func testMaterializeProducesFailures() {
-		#if os(Linux)
-			/// FIXME: skipped on Linux because of crash with swift-3.0-PREVIEW-4.
-			print("Test Case `\(#function)` skipped on Linux because of crash with swift-3.0-PREVIEW-4.")
-		#else
-			let result1 = materialize(try tryIsSuccess(nil))
-			XCTAssert(result1.error == error)
+		let result1: Result<String, AnyError> = materialize(try tryIsSuccess(nil))
+		XCTAssert(result1.error == error)
 
-			let result2: Result<String, NSError> = materialize { try tryIsSuccess(nil) }
-			XCTAssert(result2.error == error)
-		#endif
+		let result2: Result<String, AnyError> = materialize { try tryIsSuccess(nil) }
+		XCTAssert(result2.error == error)
 	}
 
 	// MARK: Recover
 
 	func testRecoverProducesLeftForLeftSuccess() {
-		let left = Result<String, NSError>.success("left")
+		let left = Result<String, Error>.success("left")
 		XCTAssertEqual(left.recover("right"), "left")
 	}
 
 	func testRecoverProducesRightForLeftFailure() {
-		struct Error: Swift.Error {}
-
-		let left = Result<String, Error>.failure(Error())
+		let left = Result<String, Error>.failure(Error.a)
 		XCTAssertEqual(left.recover("right"), "right")
 	}
 
@@ -169,13 +152,8 @@ final class ResultTests: XCTestCase {
 	}
 
 	func testTryMapProducesFailure() {
-		#if os(Linux)
-			/// FIXME: skipped on Linux because of crash with swift-3.0-PREVIEW-4.
-			print("Test Case `\(#function)` skipped on Linux because of crash with swift-3.0-PREVIEW-4.")
-		#else
-			let result = Result<String, NSError>.success("fail").tryMap(tryIsSuccess)
-			XCTAssert(result == failure)
-		#endif
+		let result = Result<String, AnyError>.success("fail").tryMap(tryIsSuccess)
+		XCTAssert(result == failure)
 	}
 
 	// MARK: Operators
@@ -202,11 +180,15 @@ final class ResultTests: XCTestCase {
 
 // MARK: - Fixtures
 
-let success = Result<String, NSError>.success("success")
-let error = NSError(domain: "com.antitypical.Result", code: 1, userInfo: nil)
-let error2 = NSError(domain: "com.antitypical.Result", code: 2, userInfo: nil)
-let failure = Result<String, NSError>.failure(error)
-let failure2 = Result<String, NSError>.failure(error2)
+private enum Error: Swift.Error {
+	case a, b
+}
+
+let success = Result<String, AnyError>.success("success")
+let error = AnyError(Error.a)
+let error2 = AnyError(Error.b)
+let failure = Result<String, AnyError>.failure(error)
+let failure2 = Result<String, AnyError>.failure(error2)
 
 
 // MARK: - Helpers


### PR DESCRIPTION
In Swift 3, `Error` should be widely used instead of `NSError`. So the type should be useful to wrap arbitrary `Error` instances for uses in generic contexts.

This is an additive, non-breaking change.