### PR TITLE
[PoC] Modify `materialize` overload of `Result<T, NSError>` to be buildable on both Swift 3.0 and 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,10 @@ matrix:
       language: generic
       install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+    - script:
+        - docker run -v `pwd`:`pwd` -w `pwd` norionomura/swift:3120170205a swift test
+      env: JOB=Linux-Swift3.1
+      sudo: required
+      services: docker
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,15 @@ matrix:
       install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
     - script:
-        - docker run -v `pwd`:`pwd` -w `pwd` norionomura/swift:3120170205a swift test
-      env: JOB=Linux-Swift3.1
+        - swift build
+        - swift test
+      env:
+        - JOB=Linux
+        - SWIFT_VERSION=3.1-DEVELOPMENT-SNAPSHOT-2017-03-01-a
       sudo: required
-      services: docker
+      dist: trusty
+      language: generic
+      install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 notifications:
   email: false

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -129,8 +129,15 @@ public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError> {
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSError> {
 	do {
 		return .success(try f())
-	} catch let error as NSError {
-		return .failure(error)
+	} catch {
+#if _runtime(_ObjC)
+		return .failure(error as NSError)
+#else
+		// https://github.com/apple/swift-corelibs-foundation/blob/swift-3.0.2-RELEASE/Foundation/NSError.swift#L314
+		let userInfo = _swift_Foundation_getErrorDefaultUserInfo(error) as? [String: Any]
+		let nsError = NSError(domain: error._domain, code: error._code, userInfo: userInfo)
+		return .failure(nsError)
+#endif
 	}
 }
 

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -130,6 +130,8 @@ public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSErro
 	do {
 		return .success(try f())
 	} catch {
+// This isn't great, but it lets us maintain compatibility until this deprecated
+// method can be removed.
 #if _runtime(_ObjC)
 		return .failure(error as NSError)
 #else


### PR DESCRIPTION
This is an alternative approach to address #212 (see also #213). This does not require major version bump so make it easy to upgrade to Swift 3.1. But I'm not confident if this is acceptable.