### PR TITLE
Improve AnyError support in `Result.init(attempt:)`

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -31,7 +31,10 @@ public enum Result<T, Error: Swift.Error>: ResultProtocol, CustomStringConvertib
 	public init(attempt f: () throws -> T) {
 		do {
 			self = .success(try f())
-		} catch {
+		} catch var error {
+			if Error.self == AnyError.self {
+				error = AnyError(error)
+			}
 			self = .failure(error as! Error)
 		}
 	}

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -233,6 +233,19 @@ final class NoErrorTests: XCTestCase {
 	}
 }
 
+final class AnyErrorTests: XCTestCase {
+	static var allTests: [(String, (AnyErrorTests) -> () throws -> Void)] {
+		return [ ("testAnyError", testAnyError) ]
+	}
+
+	func testAnyError() {
+		let error = Error.a
+		let anyErrorFromError = AnyError(error)
+		let anyErrorFromAnyError = AnyError(anyErrorFromError)
+		XCTAssertTrue(anyErrorFromError == anyErrorFromAnyError)
+	}
+}
+
 
 // MARK: - Fixtures
 

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -117,6 +117,14 @@ final class ResultTests: XCTestCase {
 		XCTAssert(result.error == error)
 	}
 
+	func testTryCatchWithFunctionThrowingNonAnyErrorCanProducesAnyErrorFailures() {
+		let nsError = NSError(domain: "", code: 0)
+		let function: () throws -> String = { throw nsError }
+
+		let result: Result<String, AnyError> = Result(attempt: function)
+		XCTAssert(result.error == AnyError(nsError))
+	}
+
 	func testMaterializeProducesSuccesses() {
 		let result1: Result<String, AnyError> = materialize(try tryIsSuccess("success"))
 		XCTAssert(result1 == success)


### PR DESCRIPTION
Originally reported in https://github.com/mdiep/Tentacle/issues/66.