### PR TITLE
Remove unavailable APIs from Result 2.x (Swift 2.x)

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -230,25 +230,6 @@ extension AnyError: LocalizedError {
 
 // MARK: - migration support
 
-extension Result {
-	@available(*, unavailable, renamed: "success")
-	public static func Success(_: T) -> Result<T, Error> {
-		fatalError()
-	}
-
-	@available(*, unavailable, renamed: "failure")
-	public static func Failure(_: Error) -> Result<T, Error> {
-		fatalError()
-	}
-}
-
-extension NSError {
-	@available(*, unavailable, renamed: "error(from:)")
-	public static func errorFromErrorType(_ error: Swift.Error) -> Self {
-		fatalError()
-	}
-}
-
 @available(*, unavailable, message: "Use the overload which returns `Result<T, AnyError>` instead")
 public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError> {
 	fatalError()

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -151,25 +151,3 @@ extension ResultProtocol {
 }
 
 // MARK: - migration support
-@available(*, unavailable, renamed: "ResultProtocol")
-public typealias ResultType = ResultProtocol
-
-@available(*, unavailable, renamed: "Error")
-public typealias ResultErrorType = Swift.Error
-
-@available(*, unavailable, renamed: "ErrorProtocolConvertible")
-public typealias ErrorTypeConvertible = ErrorProtocolConvertible
-
-extension ResultProtocol {
-	@available(*, unavailable, renamed: "recover(with:)")
-	public func recoverWith(_ result: @autoclosure () -> Self) -> Self {
-		fatalError()
-	}
-}
-
-extension ErrorProtocolConvertible {
-	@available(*, unavailable, renamed: "error(from:)")
-	public static func errorFromErrorType(_ error: Swift.Error) -> Self {
-		fatalError()
-	}
-}


### PR DESCRIPTION
There should be no problem to remove them now.