### PR TITLE
Add `LocalizedError` conformance to `AnyError` on Linux with a workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,15 @@ matrix:
       language: generic
       install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+    - script:
+        - swift build
+        - swift test
+      env: JOB=Linux
+      sudo: required
+      dist: trusty
+      language: generic
+      install:
+        - echo DEVELOPMENT-SNAPSHOT-2017-05-21-a > .swift-version
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ matrix:
       install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
     - script:
-        - swift build
-        - swift test
+        - swift test -Xswiftc -swift-version -Xswiftc 4
       env: JOB=Linux
       sudo: required
       dist: trusty

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -203,14 +203,21 @@ extension AnyError: CustomStringConvertible {
 	}
 }
 
-// There appears to be a bug in Foundation on Linux which prevents this from working:
-// https://bugs.swift.org/browse/SR-3565
-// Don't forget to comment the tests back in when removing this check when it's fixed!
-#if !os(Linux)
-
 extension AnyError: LocalizedError {
 	public var errorDescription: String? {
-		return error.localizedDescription
+		#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+			return error.localizedDescription
+		#else
+			#if swift(>=4.0)
+				// The workaround below is not needed for Swift 4.0 thanks to
+				// https://github.com/apple/swift-corelibs-foundation/pull/967.
+			#else
+				if let nsError = error as? NSError {
+					return nsError.localizedDescription
+				}
+			#endif
+			return error.localizedDescription
+		#endif
 	}
 
 	public var failureReason: String? {
@@ -225,8 +232,6 @@ extension AnyError: LocalizedError {
 		return (error as? LocalizedError)?.recoverySuggestion
 	}
 }
-
-#endif
 
 // MARK: - migration support
 

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -66,10 +66,6 @@ final class ResultTests: XCTestCase {
 		XCTAssert(Result<(), NSError>.error().function == function)
 	}
 
-//	These tests fail on linux, root cause possibly https://bugs.swift.org/browse/SR-3565
-//  Try again when it's fixed
-	#if !os(Linux)
-
 	func testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError() {
 		XCTAssertEqual(error.errorDescription, "localized description")
 		XCTAssertEqual(error.localizedDescription, "localized description")
@@ -88,8 +84,6 @@ final class ResultTests: XCTestCase {
 	func testAnyErrorDelegatesLocalizedHelpAnchorToUnderlyingError() {
 		XCTAssertEqual(error.helpAnchor, "help anchor")
 	}
-
-	#endif
 
 	// MARK: Try - Catch
 	
@@ -352,13 +346,10 @@ extension ResultTests {
 //			("testTryProducesSuccessesForOptionalAPI", testTryProducesSuccessesForOptionalAPI),
 			("testTryMapProducesSuccess", testTryMapProducesSuccess),
 			("testTryMapProducesFailure", testTryMapProducesFailure),
-
-//			These tests fail on linux, root cause possibly https://bugs.swift.org/browse/SR-3565
-//          Try again when it's fixed
-//			("testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError", testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError),
-//			("testAnyErrorDelegatesLocalizedFailureReasonToUnderlyingError", testAnyErrorDelegatesLocalizedFailureReasonToUnderlyingError),
-//			("testAnyErrorDelegatesLocalizedRecoverySuggestionToUnderlyingError", testAnyErrorDelegatesLocalizedRecoverySuggestionToUnderlyingError),
-//			("testAnyErrorDelegatesLocalizedHelpAnchorToUnderlyingError", testAnyErrorDelegatesLocalizedHelpAnchorToUnderlyingError),
+			("testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError", testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError),
+			("testAnyErrorDelegatesLocalizedFailureReasonToUnderlyingError", testAnyErrorDelegatesLocalizedFailureReasonToUnderlyingError),
+			("testAnyErrorDelegatesLocalizedRecoverySuggestionToUnderlyingError", testAnyErrorDelegatesLocalizedRecoverySuggestionToUnderlyingError),
+			("testAnyErrorDelegatesLocalizedHelpAnchorToUnderlyingError", testAnyErrorDelegatesLocalizedHelpAnchorToUnderlyingError),
 		]
 	}
 }


### PR DESCRIPTION
Supersedes #216.