### PR TITLE
[3.1] Rename ErrorProtocolConvertible to ErrorConvertible and deprecate the old name

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -174,9 +174,9 @@ public func `try`(_ function: String = #function, file: String = #file, line: In
 
 #endif
 
-// MARK: - ErrorProtocolConvertible conformance
+// MARK: - ErrorConvertible conformance
 	
-extension NSError: ErrorProtocolConvertible {
+extension NSError: ErrorConvertible {
 	public static func error(from error: Swift.Error) -> Self {
 		func cast<T: NSError>(_ error: Swift.Error) -> T {
 			return error as! T
@@ -214,7 +214,7 @@ public struct AnyError: Swift.Error {
 	}
 }
 
-extension AnyError: ErrorProtocolConvertible {
+extension AnyError: ErrorConvertible {
 	public static func error(from error: Error) -> AnyError {
 		return AnyError(error)
 	}

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -98,11 +98,11 @@ public extension ResultProtocol {
 }
 
 /// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
-public protocol ErrorProtocolConvertible: Swift.Error {
+public protocol ErrorConvertible: Swift.Error {
 	static func error(from error: Swift.Error) -> Self
 }
 
-public extension ResultProtocol where Error: ErrorProtocolConvertible {
+public extension ResultProtocol where Error: ErrorConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {
@@ -182,8 +182,11 @@ public typealias ResultType = ResultProtocol
 @available(*, unavailable, renamed: "Error")
 public typealias ResultErrorType = Swift.Error
 
-@available(*, unavailable, renamed: "ErrorProtocolConvertible")
-public typealias ErrorTypeConvertible = ErrorProtocolConvertible
+@available(*, unavailable, renamed: "ErrorConvertible")
+public typealias ErrorTypeConvertible = ErrorConvertible
+
+@available(*, deprecated, renamed: "ErrorConvertible")
+public protocol ErrorProtocolConvertible: ErrorConvertible {}
 
 extension ResultProtocol {
 	@available(*, unavailable, renamed: "recover(with:)")
@@ -192,7 +195,7 @@ extension ResultProtocol {
 	}
 }
 
-extension ErrorProtocolConvertible {
+extension ErrorConvertible {
 	@available(*, unavailable, renamed: "error(from:)")
 	public static func errorFromErrorType(_ error: Swift.Error) -> Self {
 		fatalError()


### PR DESCRIPTION
We forgot to omit `Protocol` here (refs: #176 and #178).