### PR TITLE
Rename ErrorProtocolConvertible to ErrorConvertible

### DIFF
--- a/Result/AnyError.swift
+++ b/Result/AnyError.swift
@@ -15,7 +15,7 @@ public struct AnyError: Swift.Error {
 	}
 }
 
-extension AnyError: ErrorProtocolConvertible {
+extension AnyError: ErrorConvertible {
 	public static func error(from error: Error) -> AnyError {
 		return AnyError(error)
 	}

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -151,9 +151,9 @@ public func `try`(_ function: String = #function, file: String = #file, line: In
 
 #endif
 
-// MARK: - ErrorProtocolConvertible conformance
+// MARK: - ErrorConvertible conformance
 	
-extension NSError: ErrorProtocolConvertible {
+extension NSError: ErrorConvertible {
 	public static func error(from error: Swift.Error) -> Self {
 		func cast<T: NSError>(_ error: Swift.Error) -> T {
 			return error as! T

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -98,11 +98,11 @@ public extension ResultProtocol {
 }
 
 /// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
-public protocol ErrorProtocolConvertible: Swift.Error {
+public protocol ErrorConvertible: Swift.Error {
 	static func error(from error: Swift.Error) -> Self
 }
 
-public extension ResultProtocol where Error: ErrorProtocolConvertible {
+public extension ResultProtocol where Error: ErrorConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {
@@ -151,3 +151,6 @@ extension ResultProtocol {
 }
 
 // MARK: - migration support
+
+@available(*, unavailable, renamed: "ErrorConvertible")
+public protocol ErrorProtocolConvertible: ErrorConvertible {}


### PR DESCRIPTION
Ports #230 into `master` and makes the old name unavailable.