### PR TITLE
Remove `ResultProtocol`.

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// An enum representing either a failure with an explanatory error, or a success with a result value.
-public enum Result<T, Error: Swift.Error>: ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible {
+public enum Result<T, Error: Swift.Error>: CustomStringConvertible, CustomDebugStringConvertible {
 	case success(T)
 	case failure(Error)
 

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -1,34 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-/// A type that can represent either failure with an error or success with a result value.
-public protocol ResultProtocol {
-	associatedtype Value
-	associatedtype Error: Swift.Error
-	
-	/// Constructs a successful result wrapping a `value`.
-	init(value: Value)
+public extension Result {
+	public typealias Value = T
 
-	/// Constructs a failed result wrapping an `error`.
-	init(error: Error)
-	
-	/// Case analysis for ResultProtocol.
-	///
-	/// Returns the value produced by appliying `ifFailure` to the error if self represents a failure, or `ifSuccess` to the result value if self represents a success.
-	func analysis<U>(ifSuccess: (Value) -> U, ifFailure: (Error) -> U) -> U
-
-	/// Returns the value if self represents a success, `nil` otherwise.
-	///
-	/// A default implementation is provided by a protocol extension. Conforming types may specialize it.
-	var value: Value? { get }
-
-	/// Returns the error if self represents a failure, `nil` otherwise.
-	///
-	/// A default implementation is provided by a protocol extension. Conforming types may specialize it.
-	var error: Error? { get }
-}
-
-public extension ResultProtocol {
-	
 	/// Returns the value if self represents a success, `nil` otherwise.
 	public var value: Value? {
 		return analysis(ifSuccess: { $0 }, ifFailure: { _ in nil })
@@ -53,9 +27,7 @@ public extension ResultProtocol {
 
 	/// Returns a Result with a tuple of the receiver and `other` values if both
 	/// are `Success`es, or re-wrapping the error of the earlier `Failure`.
-	public func fanout<R: ResultProtocol>(_ other: @autoclosure () -> R) -> Result<(Value, R.Value), Error>
-		where Error == R.Error
-	{
+	public func fanout<U>(_ other: @autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error> {
 		return self.flatMap { left in other().map { right in (left, right) } }
 	}
 
@@ -80,7 +52,7 @@ public extension ResultProtocol {
 	}
 }
 
-public extension ResultProtocol {
+public extension Result {
 
 	// MARK: Higher-order functions
 
@@ -90,7 +62,7 @@ public extension ResultProtocol {
 	}
 
 	/// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
-	public func recover(with result: @autoclosure () -> Self) -> Self {
+	public func recover(with result: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error> {
 		return analysis(
 			ifSuccess: { _ in self },
 			ifFailure: { _ in result() })
@@ -102,7 +74,7 @@ public protocol ErrorProtocolConvertible: Swift.Error {
 	static func error(from error: Swift.Error) -> Self
 }
 
-public extension ResultProtocol where Error: ErrorProtocolConvertible {
+public extension Result where Error: ErrorProtocolConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {
@@ -121,9 +93,9 @@ public extension ResultProtocol where Error: ErrorProtocolConvertible {
 
 // MARK: - Operators
 
-extension ResultProtocol where Value: Equatable, Error: Equatable {
+extension Result where T: Equatable, Error: Equatable {
 	/// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
-	public static func ==(left: Self, right: Self) -> Bool {
+	public static func ==(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool {
 		if let left = left.value, let right = right.value {
 			return left == right
 		} else if let left = left.error, let right = right.error {
@@ -133,19 +105,19 @@ extension ResultProtocol where Value: Equatable, Error: Equatable {
 	}
 
 	/// Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.
-	public static func !=(left: Self, right: Self) -> Bool {
+	public static func !=(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool {
 		return !(left == right)
 	}
 }
 
-extension ResultProtocol {
+extension Result {
 	/// Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.
-	public static func ??(left: Self, right: @autoclosure () -> Value) -> Value {
+	public static func ??(left: Result<Value, Error>, right: @autoclosure () -> Value) -> Value {
 		return left.recover(right())
 	}
 
 	/// Returns `left` if it is a `Success`es, or `right` otherwise. Short-circuits.
-	public static func ??(left: Self, right: @autoclosure () -> Self) -> Self {
+	public static func ??(left: Result<Value, Error>, right: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error> {
 		return left.recover(with: right())
 	}
 }


### PR DESCRIPTION
No operator requires it, and AFAIU `Result` is built on the assumption/premises of providing a currency type rather than defining a generic protocol.