### PR TITLE
Deprecate `materialize` functions

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -132,10 +132,12 @@ extension Result where Error == AnyError {
 
 // MARK: - Derive result from failable closure
 
+@available(*, deprecated, renamed: "Result.init(attempt:)")
 public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError> {
 	return Result(attempt: f)
 }
 
+@available(*, deprecated, renamed: "Result.init(_:)")
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError> {
 	return Result(f)
 }

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -120,18 +120,18 @@ final class ResultTests: XCTestCase {
 	}
 
 	func testMaterializeProducesSuccesses() {
-		let result1: Result<String, AnyError> = materialize(try tryIsSuccess("success"))
+		let result1: Result<String, AnyError> = Result(try tryIsSuccess("success"))
 		XCTAssert(result1 == success)
 
-		let result2: Result<String, AnyError> = materialize { try tryIsSuccess("success") }
+		let result2: Result<String, AnyError> = Result(attempt: { try tryIsSuccess("success") })
 		XCTAssert(result2 == success)
 	}
 
 	func testMaterializeProducesFailures() {
-		let result1: Result<String, AnyError> = materialize(try tryIsSuccess(nil))
+		let result1: Result<String, AnyError> = Result(try tryIsSuccess(nil))
 		XCTAssert(result1.error == error)
 
-		let result2: Result<String, AnyError> = materialize { try tryIsSuccess(nil) }
+		let result2: Result<String, AnyError> = Result(attempt: { try tryIsSuccess(nil) })
 		XCTAssert(result2.error == error)
 	}
 


### PR DESCRIPTION
A follow-up for #236 (and #233).