### PR TITLE
Add initializers to ResultProtocol

### DIFF
--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -5,6 +5,9 @@ public protocol ResultProtocol {
 	associatedtype Value
 	associatedtype Error: Swift.Error
 
+	init(value: Value)
+	init(error: Error)
+	
 	var result: Result<Value, Error> { get }
 }
 


### PR DESCRIPTION
Hi! I'd like to propose adding back the initializers to `ResultProtocol`. This will allow creation of `ResultProtocol` 'instances'  in contexts where it is used as a type constraint. More specifically, I would need it to be able to upgrade BrightFutures to use Result `master`. For example usage see, https://github.com/Thomvis/BrightFutures/blob/master/Sources/BrightFutures/MutableAsyncType+ResultType.swift#L17.

I understand these were removed in #235, as part of an effort to reduce `ResultProtocol`'s responsibilities. I don't think I understand the reasoning behind that PR, so I apologise if I'm missing something obvious.

Thanks!