### PR TITLE
[gardening] Use `switch self` over `analysis`

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -96,9 +96,10 @@ public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConve
 	// MARK: CustomStringConvertible
 
 	public var description: String {
-		return analysis(
-			ifSuccess: { ".success(\($0))" },
-			ifFailure: { ".failure(\($0))" })
+		switch self {
+		case let .success(value): return ".success(\(value))"
+		case let .failure(error): return ".failure(\(error))"
+		}
 	}
 
 


### PR DESCRIPTION
This is possible now because all methods and properties are implemented on the concrete `Result` enum.