### PR TITLE
[3.x] Deprecate `try` functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - swift test
       env:
         - JOB=Linux
-        - SWIFT_VERSION=3.1-DEVELOPMENT-SNAPSHOT-2017-03-01-a
+        - SWIFT_VERSION=3.1
       sudo: required
       dist: trusty
       language: generic

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -155,7 +155,7 @@ public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSErro
 /// This is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:
 ///
 ///     Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }
-@available(*, deprecated, message: "This will be removed in Result 4.0. See https://github.com/antitypical/Result/issues/85 for the details.")
+@available(*, deprecated, message: "This will be removed in Result 4.0. Use `Result.init(attempt:)` instead. See https://github.com/antitypical/Result/issues/85 for the details.")
 public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> T?) -> Result<T, NSError> {
 	var error: NSError?
 	return `try`(&error).map(Result.success) ?? .failure(error ?? Result<T, NSError>.error(function: function, file: file, line: line))
@@ -166,7 +166,7 @@ public func `try`<T>(_ function: String = #function, file: String = #file, line:
 /// This is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:
 ///
 ///     Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }
-@available(*, deprecated, message: "This will be removed in Result 4.0. See https://github.com/antitypical/Result/issues/85 for the details.")
+@available(*, deprecated, message: "This will be removed in Result 4.0. Use `Result.init(attempt:)` instead. See https://github.com/antitypical/Result/issues/85 for the details.")
 public func `try`(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> Bool) -> Result<(), NSError> {
 	var error: NSError?
 	return `try`(&error) ?

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -155,6 +155,7 @@ public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSErro
 /// This is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:
 ///
 ///     Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }
+@available(*, deprecated, message: "This will be removed in Result 4.0. See https://github.com/antitypical/Result/issues/85 for the details.")
 public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> T?) -> Result<T, NSError> {
 	var error: NSError?
 	return `try`(&error).map(Result.success) ?? .failure(error ?? Result<T, NSError>.error(function: function, file: file, line: line))
@@ -165,6 +166,7 @@ public func `try`<T>(_ function: String = #function, file: String = #file, line:
 /// This is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:
 ///
 ///     Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }
+@available(*, deprecated, message: "This will be removed in Result 4.0. See https://github.com/antitypical/Result/issues/85 for the details.")
 public func `try`(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> Bool) -> Result<(), NSError> {
 	var error: NSError?
 	return `try`(&error) ?


### PR DESCRIPTION
Those will be removed in Result 4.0.

This is a preparation for #85.