### PR TITLE
[4.0] Make `try` functions unavailable

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -143,34 +143,6 @@ public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyErr
 	return Result(f)
 }
 
-// MARK: - Cocoa API conveniences
-
-#if !os(Linux)
-
-/// Constructs a `Result` with the result of calling `try` with an error pointer.
-///
-/// This is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:
-///
-///     Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }
-public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> T?) -> Result<T, NSError> {
-	var error: NSError?
-	return `try`(&error).map(Result.success) ?? .failure(error ?? Result<T, NSError>.error(function: function, file: file, line: line))
-}
-
-/// Constructs a `Result` with the result of calling `try` with an error pointer.
-///
-/// This is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:
-///
-///     Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }
-public func `try`(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> Bool) -> Result<(), NSError> {
-	var error: NSError?
-	return `try`(&error) ?
-		.success(())
-	:	.failure(error ?? Result<(), NSError>.error(function: function, file: file, line: line))
-}
-
-#endif
-
 // MARK: - ErrorConvertible conformance
 	
 extension NSError: ErrorConvertible {
@@ -194,6 +166,30 @@ public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError> {
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSError> {
 	fatalError()
 }
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+
+/// Constructs a `Result` with the result of calling `try` with an error pointer.
+///
+/// This is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:
+///
+///     Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }
+@available(*, unavailable, message: "This has been removed. Use `Result.init(attempt:)` instead. See https://github.com/antitypical/Result/issues/85 for the details.")
+public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> T?) -> Result<T, NSError> {
+	fatalError()
+}
+
+/// Constructs a `Result` with the result of calling `try` with an error pointer.
+///
+/// This is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:
+///
+///     Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }
+@available(*, unavailable, message: "This has been removed. Use `Result.init(attempt:)` instead. See https://github.com/antitypical/Result/issues/85 for the details.")
+public func `try`(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> Bool) -> Result<(), NSError> {
+	fatalError()
+}
+
+#endif
 
 // MARK: -
 

--- a/Tests/ResultTests/ResultTests.swift
+++ b/Tests/ResultTests/ResultTests.swift
@@ -179,36 +179,6 @@ final class ResultTests: XCTestCase {
 		XCTAssertEqual(left.recover(with: right).error, .right)
 	}
 
-	// MARK: Cocoa API idioms
-
-	#if !os(Linux)
-
-	func testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference() {
-		let result = `try` { attempt(true, succeed: false, error: $0) }
-		XCTAssertFalse(result ?? false)
-		XCTAssertNotNil(result.error)
-	}
-
-	func testTryProducesFailuresForOptionalWithErrorReturnedByReference() {
-		let result = `try` { attempt(1, succeed: false, error: $0) }
-		XCTAssertEqual(result ?? 0, 0)
-		XCTAssertNotNil(result.error)
-	}
-
-	func testTryProducesSuccessesForBooleanAPI() {
-		let result = `try` { attempt(true, succeed: true, error: $0) }
-		XCTAssertTrue(result ?? false)
-		XCTAssertNil(result.error)
-	}
-
-	func testTryProducesSuccessesForOptionalAPI() {
-		let result = `try` { attempt(1, succeed: true, error: $0) }
-		XCTAssertEqual(result ?? 0, 1)
-		XCTAssertNil(result.error)
-	}
-
-	#endif
-
 	func testTryMapProducesSuccess() {
 		let result = success.tryMap(tryIsSuccess)
 		XCTAssert(result == success)
@@ -259,19 +229,6 @@ extension AnyError: Equatable {
 	}
 }
 
-#if !os(Linux)
-
-func attempt<T>(_ value: T, succeed: Bool, error: NSErrorPointer) -> T? {
-	if succeed {
-		return value
-	} else {
-		error?.pointee = Result<(), NSError>.error()
-		return nil
-	}
-}
-
-#endif
-
 func tryIsSuccess(_ text: String?) throws -> String {
 	guard let text = text, text == "success" else {
 		throw error
@@ -293,8 +250,6 @@ extension NSError {
 		return userInfo[Result<(), NSError>.lineKey] as? Int
 	}
 }
-
-#if os(Linux)
 
 extension ResultTests {
 	static var allTests: [(String, (ResultTests) -> () throws -> Void)] {
@@ -320,10 +275,6 @@ extension ResultTests {
 			("testRecoverWithProducesLeftForLeftSuccess", testRecoverWithProducesLeftForLeftSuccess),
 			("testRecoverWithProducesRightSuccessForLeftFailureAndRightSuccess", testRecoverWithProducesRightSuccessForLeftFailureAndRightSuccess),
 			("testRecoverWithProducesRightFailureForLeftFailureAndRightFailure", testRecoverWithProducesRightFailureForLeftFailureAndRightFailure),
-//			("testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference", testTryProducesFailuresForBooleanAPIWithErrorReturnedByReference),
-//			("testTryProducesFailuresForOptionalWithErrorReturnedByReference", testTryProducesFailuresForOptionalWithErrorReturnedByReference),
-//			("testTryProducesSuccessesForBooleanAPI", testTryProducesSuccessesForBooleanAPI),
-//			("testTryProducesSuccessesForOptionalAPI", testTryProducesSuccessesForOptionalAPI),
 			("testTryMapProducesSuccess", testTryMapProducesSuccess),
 			("testTryMapProducesFailure", testTryMapProducesFailure),
 			("testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError", testAnyErrorDelegatesLocalizedDescriptionToUnderlyingError),
@@ -333,8 +284,6 @@ extension ResultTests {
 		]
 	}
 }
-
-#endif
 
 import Foundation
 import Result


### PR DESCRIPTION
Resolves #85.

The functions have been deprecated by #251 on Result 3.x.