### PR TITLE
`Swift.Error::anyError` computed property.

### DIFF
--- a/Result/AnyError.swift
+++ b/Result/AnyError.swift
@@ -44,3 +44,13 @@ extension AnyError: LocalizedError {
 		return (error as? LocalizedError)?.recoverySuggestion
 	}
 }
+
+/// `Swift.Error` extension.
+public extension Swift.Error {
+
+	/// Returns `AnyError` instance if `self` is `AnyError`; otherwise creates
+	/// `AnyError` instance with `self`.
+	public var anyError: AnyError {
+		return self as? AnyError ?? AnyError(self)
+	}
+}

--- a/Tests/ResultTests/AnyErrorTests.swift
+++ b/Tests/ResultTests/AnyErrorTests.swift
@@ -4,13 +4,20 @@ import Result
 
 final class AnyErrorTests: XCTestCase {
 	static var allTests: [(String, (AnyErrorTests) -> () throws -> Void)] {
-		return [ ("testAnyError", testAnyError) ]
+		return [ ("testAnyError", testAnyError), ("testSwiftErrorAnyError", testSwiftErrorAnyError) ]
 	}
 
 	func testAnyError() {
 		let error = Error.a
 		let anyErrorFromError = AnyError(error)
 		let anyErrorFromAnyError = AnyError(anyErrorFromError)
+		XCTAssertTrue(anyErrorFromError == anyErrorFromAnyError)
+	}
+
+	func testSwiftErrorAnyError() {
+		let error = Error.a
+		let anyErrorFromError = error.anyError
+		let anyErrorFromAnyError = anyErrorFromError.anyError
 		XCTAssertTrue(anyErrorFromError == anyErrorFromAnyError)
 	}
 }


### PR DESCRIPTION
I think it is better than using `AnyError::init`, because it is not obvious (for API user) that `AnyError::init` will not produce double boxing for `AnyError` errors. And result syntax looks not bad `Future<..., AnyError>(error: error.anyError)`.