### PR TITLE
Fix swift_version on podspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - xcodebuild $XCODE_ACTION -scheme Result-iOS -sdk iphonesimulator -destination "name=iPhone SE" | xcpretty
         - xcodebuild $XCODE_ACTION -scheme Result-tvOS -sdk appletvsimulator -destination "name=Apple TV" | xcpretty
         - xcodebuild build -scheme Result-watchOS -sdk watchsimulator | xcpretty
-        - gem update cocoapods && rm .swift-version && pod lib lint
+        - gem install cocoapods -v "~> 1.5.0" && pod lib lint
       env:
         - JOB=Xcode
         - XCODE_ACTION="build-for-testing test-without-building"
@@ -23,7 +23,7 @@ matrix:
         - xcodebuild $XCODE_ACTION -scheme Result-iOS -sdk iphonesimulator -destination "name=iPhone SE" | xcpretty
         - xcodebuild $XCODE_ACTION -scheme Result-tvOS -sdk appletvsimulator -destination "name=Apple TV" | xcpretty
         - xcodebuild build -scheme Result-watchOS -sdk watchsimulator | xcpretty
-        - rm .swift-version && pod lib lint
+        - gem install cocoapods -v "~> 1.5.0" && pod lib lint
       env:
         - JOB=Xcode
         - XCODE_ACTION="build-for-testing test-without-building"

--- a/Result.podspec
+++ b/Result.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   
   s.swift_version = '4.1'
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.5.0'
 end

--- a/Result.podspec
+++ b/Result.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   
-  s.swift_version = '4.0'
+  s.swift_version = '4.1'
   s.cocoapods_version = '>= 1.4.0'
 end


### PR DESCRIPTION
Just run `pod lib lint` on this repository, CocoaPods raises following error.

```
Result (master) ~ pod lib lint

 -> Result
 -> Result (4.0.0)
    - ERROR | swift: Specification `Result` specifies an inconsistent `swift_version` (`4.0`) compared to the one present in your `.swift-version` file (`4.1`). Please remove the `.swift-version` file which is now deprecated and only use the `swift_version` attribute within your podspec.

[!] Result did not pass validation, due to 1 error.
You can use the `--no-clean` option to inspect any issue.

```

Why did it mismatch between `podspec` and `.swift_version`?

I think it is strange.
Result 4.0 supports only above Swift 4.1, so `*.podspec` should be fixed.