### PR TITLE
Add compatibility with Swift 5's Result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,18 @@ matrix:
       language: generic
       install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+    - script:
+        - swift --version
+        - swift build
+        - swift test
+      env:
+        - JOB=Linux
+        - SWIFT_VERSION=5.0-DEVELOPMENT-SNAPSHOT-2018-12-28-a
+      sudo: required
+      dist: trusty
+      language: generic
+      install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 
 notifications:
   email: false

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "Result",
+    products: [
+        .library(name: "Result", targets: ["Result"]),
+    ],
+    targets: [
+        .target(name: "Result", dependencies: [], path: "Result"),
+        .testTarget(name: "ResultTests", dependencies: ["Result"]),
+    ],
+    swiftLanguageVersions: [.v4, .v4_2, .v5]
+)

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -173,7 +173,7 @@ public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError> {
 
 @available(*, deprecated, renamed: "Result.init(_:)")
 public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError> {
-	return Result(f)
+	return Result(try f())
 }
 
 // MARK: - ErrorConvertible conformance

--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -5,6 +5,19 @@ public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConve
 	case success(Value)
 	case failure(Error)
 
+	/// The compatibility alias for the Swift 5's `Result` in the standard library.
+	///
+	/// See https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md
+	/// and https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603
+	/// for the details.
+	public typealias Success = Value
+	/// The compatibility alias for the Swift 5's `Result` in the standard library.
+	///
+	/// See https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md
+	/// and https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603
+	/// for the details.
+	public typealias Failure = Error
+
 	// MARK: Constructors
 
 	/// Constructs a success wrapping a `value`.
@@ -24,13 +37,23 @@ public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConve
 
 	/// Constructs a result from a function that uses `throw`, failing with `Error` if throws.
 	public init(_ f: @autoclosure () throws -> Value) {
-		self.init(attempt: f)
+		self.init(catching: f)
 	}
 
 	/// Constructs a result from a function that uses `throw`, failing with `Error` if throws.
+	@available(*, deprecated, renamed: "init(catching:)")
 	public init(attempt f: () throws -> Value) {
+		self.init(catching: f)
+	}
+
+	/// The same as `init(attempt:)` aiming for the compatibility with the Swift 5's `Result` in the standard library.
+	///
+	/// See https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md
+	/// and https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603
+	/// for the details.
+	public init(catching body: () throws -> Success) {
 		do {
-			self = .success(try f())
+			self = .success(try body())
 		} catch var error {
 			if Error.self == AnyError.self {
 				error = AnyError(error)
@@ -42,7 +65,17 @@ public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConve
 	// MARK: Deconstruction
 
 	/// Returns the value from `success` Results or `throw`s the error.
+	@available(*, deprecated, renamed: "get()")
 	public func dematerialize() throws -> Value {
+		return try get()
+	}
+
+	/// The same as `dematerialize()` aiming for the compatibility with the Swift 5's `Result` in the standard library.
+	///
+	/// See https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md
+	/// and https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603
+	/// for the details.
+	public func get() throws -> Success {
 		switch self {
 		case let .success(value):
 			return value
@@ -115,7 +148,7 @@ public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConve
 	}
 }
 
-extension Result where Error == AnyError {
+extension Result where Result.Failure == AnyError {
 	/// Constructs a result from an expression that uses `throw`, failing with `AnyError` if throws.
 	public init(_ f: @autoclosure () throws -> Value) {
 		self.init(attempt: f)

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -11,7 +11,7 @@ public protocol ResultProtocol {
 	var result: Result<Value, Error> { get }
 }
 
-public extension Result {
+extension Result {
 	/// Returns the value if self represents a success, `nil` otherwise.
 	public var value: Value? {
 		switch self {
@@ -69,7 +69,7 @@ public extension Result {
 	}
 }
 
-public extension Result {
+extension Result {
 
 	// MARK: Higher-order functions
 
@@ -92,7 +92,7 @@ public protocol ErrorConvertible: Swift.Error {
 	static func error(from error: Swift.Error) -> Self
 }
 
-public extension Result where Result.Failure: ErrorConvertible {
+extension Result where Result.Failure: ErrorConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {

--- a/Result/ResultProtocol.swift
+++ b/Result/ResultProtocol.swift
@@ -92,7 +92,7 @@ public protocol ErrorConvertible: Swift.Error {
 	static func error(from error: Swift.Error) -> Self
 }
 
-public extension Result where Error: ErrorConvertible {
+public extension Result where Result.Failure: ErrorConvertible {
 
 	/// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
 	public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {
@@ -111,7 +111,7 @@ public extension Result where Error: ErrorConvertible {
 
 // MARK: - Operators
 
-extension Result where Value: Equatable, Error: Equatable {
+extension Result where Result.Success: Equatable, Result.Failure: Equatable {
 	/// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
 	public static func ==(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool {
 		if let left = left.value, let right = right.value {
@@ -124,9 +124,9 @@ extension Result where Value: Equatable, Error: Equatable {
 }
 
 #if swift(>=4.1)
-	extension Result: Equatable where Value: Equatable, Error: Equatable { }
+	extension Result: Equatable where Result.Success: Equatable, Result.Failure: Equatable { }
 #else
-	extension Result where Value: Equatable, Error: Equatable {
+	extension Result where Result.Success: Equatable, Result.Failure: Equatable {
 		/// Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.
 		public static func !=(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool {
 			return !(left == right)


### PR DESCRIPTION
This aims at providing a migration path for the Result type in the Swift 5's standard library.

- https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md
- https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603