### PR TITLE
Deprecate NoError enum

### DIFF
--- a/Result/NoError.swift
+++ b/Result/NoError.swift
@@ -3,8 +3,17 @@
 /// This can be used to describe `Result`s where failures will never
 /// be generated. For example, `Result<Int, NoError>` describes a result that
 /// contains an `Int`eger and is guaranteed never to be a `failure`.
+#if swift(>=5.0)
+@available(*, deprecated, message: "Use `Swift.Never` instead", renamed: "Never")
 public enum NoError: Swift.Error, Equatable {
 	public static func ==(lhs: NoError, rhs: NoError) -> Bool {
 		return true
 	}
 }
+#else
+public enum NoError: Swift.Error, Equatable {
+	public static func ==(lhs: NoError, rhs: NoError) -> Bool {
+		return true
+	}
+}
+#endif


### PR DESCRIPTION
Hi.

I suggest deprecating `NoError` in favor of native `Never` since it conforms to Error & Equatable.

My view of releases for smooth migration in this case:
v5.0 - Deprecate enum
v6.0 - Replace enum with deprecated type alias
v6.1 - Remove type alias
