### PR TITLE
Move `import Foundation` statement to top in Result.swift

### DIFF
--- a/Result/Result.swift
+++ b/Result/Result.swift
@@ -1,5 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+import Foundation
+
 #if swift(>=4.2)
 #if compiler(>=5)
 
@@ -282,7 +284,3 @@ public func `try`(_ function: String = #function, file: String = #file, line: In
 }
 
 #endif
-
-// MARK: -
-
-import Foundation


### PR DESCRIPTION
The standard Swift coding convention is to have `import` statements on the top of the file.

Also, code completion results only show up after the `import` statement, so this change ensures that declarations from the `Foundation` module are correctly suggested in this file.